### PR TITLE
Allow Interface boundary conditions

### DIFF
--- a/docs/src/boundary_conditions.md
+++ b/docs/src/boundary_conditions.md
@@ -101,3 +101,39 @@ u(t, x_min, y) ~ u(t, x_max, y)
 v(t, x, y_max) ~ u(t, x_max, y)
 ```
 Please note that if you want to use a periodic condition on a dimension with WENO schemes, please use a periodic condition on all variables in that dimension.
+
+## Interfaces
+You may want to connect regions with differing dynamics together, to do this follow the following example, splitting the variable that spans these domains:
+```julia
+    @parameters t x1 x2
+    @variables c1(..)
+    @variables c2(..)
+    Dt = Differential(t)
+
+    Dx1 = Differential(x1)
+    Dxx1 = Dx1^2
+
+    Dx2 = Differential(x2)
+    Dxx2 = Dx2^2
+
+    D1(c) = 1 + c / 10
+    D2(c) = 1 / 10 + c / 10
+
+    eqs = [Dt(c1(t, x1)) ~ Dx1(D1(c1(t, x1)) * Dx1(c1(t, x1))),
+        Dt(c2(t, x2)) ~ Dx2(D2(c2(t, x2)) * Dx2(c2(t, x2)))]
+
+    bcs = [c1(0, x1) ~ 1 + cospi(2 * x1),
+        c2(0, x2) ~ 1 + cospi(2 * x2),
+        Dx1(c1(t, 0)) ~ 0,
+        c1(t, 0.5) ~ c2(t, 0.5), # Relevant interface boundary condition
+        -D1(c1(t, 0.5)) * Dx1(c1(t, 0.5)) ~ -D2(c2(t, 0.5)) * Dx2(c2(t, 0.5)), # Higher order interface condition
+        Dx2(c2(t, 1)) ~ 0]
+
+    domains = [t ∈ Interval(0.0, 0.15),
+        x1 ∈ Interval(0.0, 0.5),
+        x2 ∈ Interval(0.5, 1.0)]
+
+    @named pdesys = PDESystem(eqs, bcs, domains,
+        [t, x1, x2], [c1(t, x1), c2(t, x2)])
+```
+Note that if you want to use a higher order interface condition, this may not work if you have no simple condition of the form `c1(t, 0.5) ~ c2(t, 0.5)`.

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -30,15 +30,13 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Method
     bcorders = Dict(map(x -> x => d_orders(x, pdesys.bcs), all_ivs(v)))
     # Create a map of each variable to their boundary conditions including initial conditions
     boundarymap = parse_bcs(pdesys.bcs, v, bcorders)
-    # Generate a map of each variable to whether it is periodic in a given direction
-    #TODO: fully deprecate PeriodicMap
-    pmap = PeriodicMap(boundarymap, v)
+
     # Transform system so that it is compatible with the discretization
     if discretization.should_transform
         if has_interfaces(boundarymap)
             @warn "The system contains interface boundaries, which are not compatible with system transformation. The system will not be transformed. Please post an issue if you need this feature."
         else
-            pdesys, pmap = transform_pde_system!(v, boundarymap, pmap, pdesys)
+            pdesys = transform_pde_system!(v, boundarymap, pdesys)
         end
     end
 
@@ -122,7 +120,7 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Method
             if disc_strategy isa ScalarizedDiscretization
                 # Generate the equations for the interior points
                 discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap,
-                    depvars, s, derivweights, indexmap, pmap)
+                    depvars, s, derivweights, indexmap)
             else
                 throw(ArgumentError("Only ScalarizedDiscretization is currently supported"))
             end

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -70,7 +70,7 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Method
     s = DiscreteSpace(v, discretization)
     # Get the interior and variable to solve for each equation
     #TODO: do the interiormap before and independent of the discretization i.e. `s`
-    interiormap = InteriorMap(pdeeqs, boundarymap, s, discretization, pmap)
+    interiormap = InteriorMap(pdeeqs, boundarymap, s, discretization)
     # Get the derivative orders appearing in each equation
     pdeorders = Dict(map(x -> x => d_orders(x, pdeeqs), v.x̄))
     bcorders = Dict(map(x -> x => d_orders(x, bcs), v.x̄))

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -143,7 +143,7 @@ function SciMLBase.discretize(pdesys::PDESystem,discretization::MethodOfLines.MO
     try
         simpsys = structural_simplify(sys)
         if tspan === nothing
-            add_metadata!(simpsys.metadata, sys)
+            add_metadata!(get_metadata(sys), sys)
             return prob = NonlinearProblem(simpsys, ones(length(simpsys.states)); discretization.kwargs...)
         else
             # Use ODAE if nessesary

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -31,6 +31,7 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Method
     # Create a map of each variable to their boundary conditions including initial conditions
     boundarymap = parse_bcs(pdesys.bcs, v, bcorders)
     # Generate a map of each variable to whether it is periodic in a given direction
+    #TODO: fully deprecate PeriodicMap
     pmap = PeriodicMap(boundarymap, v)
     # Transform system so that it is compatible with the discretization
     if discretization.should_transform

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -34,7 +34,11 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Method
     pmap = PeriodicMap(boundarymap, v)
     # Transform system so that it is compatible with the discretization
     if discretization.should_transform
-        pdesys, pmap = transform_pde_system!(v, boundarymap, pmap, pdesys)
+        if has_interfaces(boundarymap)
+            @warn "The system contains interface boundaries, which are not compatible with system transformation. The system will not be transformed. Please post an issue if you need this feature."
+        else
+            pdesys, pmap = transform_pde_system!(v, boundarymap, pmap, pdesys)
+        end
     end
 
     # Check if the boundaries warrant using ODAEProblem, as long as this is allowed in the interface

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -149,10 +149,10 @@ function SciMLBase.discretize(pdesys::PDESystem,discretization::MethodOfLines.MO
         else
             # Use ODAE if nessesary
             if getfield(sys, :metadata) isa MOLMetadata && getfield(sys, :metadata).use_ODAE
-                add_metadata!(simpsys.metadata, DAEProblem(simpsys; discretization.kwargs...))
+                add_metadata!(get_metadata(simpsys), DAEProblem(simpsys; discretization.kwargs...))
                 return prob = ODAEProblem(simpsys, Pair[], tspan; discretization.kwargs...)
             else
-                add_metadata!(simpsys.metadata, sys)
+                add_metadata!(get_metadata(simpsys), sys)
                 return prob = ODEProblem(simpsys, Pair[], tspan; discretization.kwargs...)
             end
         end

--- a/src/MOL_utils.jl
+++ b/src/MOL_utils.jl
@@ -269,29 +269,6 @@ remove(v::AbstractVector, a::Number) = filter(x -> !isequal(x, a), v)
 
 half_range(x) = -div(x, 2):div(x, 2)
 
-@inline function _wrapperiodic(I, N, j, l)
-    I1 = unitindex(N, j)
-    # -1 because of the relation u[1] ~ u[end]
-    if I[j] <= 1
-        I = I + I1 * (l - 1)
-    elseif I[j] > l
-        I = I - I1 * (l - 1)
-    end
-    return I
-end
-
-"""
-Allow stencils indexing over periodic boundaries. Index through this function.
-"""
-@inline function wrapperiodic(I, s, ::Val{true}, u, jx)
-    j, x = jx
-    return _wrapperiodic(I, ndims(u, s), j, length(s, x))
-end
-
-@inline function wrapperiodic(I, s, ::Val{false}, u, jx)
-    return I
-end
-
 d_orders(x, pdeeqs) = reverse(sort(collect(union((differential_order(pde.rhs, safe_unwrap(x)) for pde in pdeeqs)..., (differential_order(pde.lhs, safe_unwrap(x)) for pde in pdeeqs)...))))
 
 insert(args...) = insert!(args[1], args[2:end]...)

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -19,6 +19,7 @@ import Base.display
 import Base.isequal
 import Base.getindex
 import Base.checkindex
+import Base.checkbounds
 import Base.getproperty
 import Base.ndims
 

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -76,6 +76,9 @@ include("error_analysis.jl")
 include("scalar_discretization.jl")
 include("MOL_discretization.jl")
 
+# Convenience functions
+include("interface/solution/solution_utils.jl")
+
 export MOLFiniteDifference, discretize, symbolic_discretize, ODEFunctionExpr, generate_code, grid_align, edge_align, center_align, get_discrete
 export UpwindScheme, WENOScheme
 

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -50,6 +50,9 @@ include("system_parsing/bcs/parse_boundaries.jl")
 include("system_parsing/bcs/periodic_map.jl")
 include("system_parsing/pde_system_transformation.jl")
 
+# Interface handling
+include("discretization/interface_boundary.jl")
+
 # Schemes
 include("discretization/schemes/centered_difference/centered_difference.jl")
 include("discretization/schemes/upwind_difference/upwind_difference.jl")

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -76,9 +76,6 @@ include("error_analysis.jl")
 include("scalar_discretization.jl")
 include("MOL_discretization.jl")
 
-# Convenience functions
-include("interface/solution/solution_utils.jl")
-
 export MOLFiniteDifference, discretize, symbolic_discretize, ODEFunctionExpr, generate_code, grid_align, edge_align, center_align, get_discrete
 export UpwindScheme, WENOScheme
 

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -3,7 +3,7 @@ using LinearAlgebra
 using SciMLBase
 using DiffEqBase
 using ModelingToolkit
-using ModelingToolkit: operation, istree, arguments, variable
+using ModelingToolkit: operation, istree, arguments, variable, get_metadata
 using SymbolicUtils, Symbolics
 using Symbolics: unwrap, solve_for, expand_derivatives, diff2term, setname, rename, similarterm
 using SymbolicUtils: operation, arguments
@@ -16,6 +16,8 @@ import DomainSets
 # To Extend
 import SciMLBase.wrap_sol
 import Base.display
+import Base.isequal
+import Base.getindex
 
 
 # Interface

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -18,7 +18,9 @@ import SciMLBase.wrap_sol
 import Base.display
 import Base.isequal
 import Base.getindex
-
+import Base.checkindex
+import Base.getproperty
+import Base.ndims
 
 # Interface
 include("interface/grid_types.jl")

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -170,7 +170,7 @@ nvars(::DiscreteSpace{N,M}) where {N,M} = M
 Fillter out the time variable and get the spatial variables of `u` in `s`.
 """
 params(u, s::DiscreteSpace) = remove(s.args[operation(u)], s.time)
-Base.ndims(u, s::DiscreteSpace) = length(params(u, s))
+Base.ndims(u, s::DiscreteSpace) = ndims(s.discvars[depvar(u, s)])
 
 Base.length(s::DiscreteSpace, x) = length(s.grid[x])
 Base.length(s::DiscreteSpace, j::Int) = length(s.grid[s.x̄[j]])

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -101,7 +101,6 @@ function DiscreteSpace(vars, discretization::MOLFiniteDifference{G}) where {G}
         end
         x => discx
     end
-    @show vars
     # Define the grid on which the dependent variables will be evaluated (see #378)
     # center_align is recommended for Dirichlet BCs
     # edge_align is recommended for Neumann BCs (spatial discretization is conservative)

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -101,7 +101,7 @@ function DiscreteSpace(vars, discretization::MOLFiniteDifference{G}) where {G}
         end
         x => discx
     end
-
+    @show vars
     # Define the grid on which the dependent variables will be evaluated (see #378)
     # center_align is recommended for Dirichlet BCs
     # edge_align is recommended for Neumann BCs (spatial discretization is conservative)

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -185,6 +185,7 @@ of `II` that corresponds to only the spatial arguments of `u`.
 @inline function Idx(II::CartesianIndex, s::DiscreteSpace, u, indexmap)
     # We need to construct a new index as indices may be of different size
     length(params(u, s)) == 0 && return CartesianIndex()
+    !all(x -> haskey(indexmap, x), params(u, s)) && return II
     is = [II[indexmap[x]] for x in params(u, s)]
 
     II = CartesianIndex(is...)

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -148,7 +148,6 @@ function DiscreteSpace(vars, discretization::MOLFiniteDifference{G}) where {G}
     return DiscreteSpace{nspace,length(depvars),G}(vars, Dict(depvarsdisc), axies, grid, Dict(dxs), Dict(Iaxies), Dict(Igrid))
 end
 
-import Base.getproperty
 
 function Base.getproperty(s::DiscreteSpace, p::Symbol)
     if p in [:ū, :x̄, :time, :args, :x2i, :i2x]

--- a/src/discretization/generate_bc_eqs.jl
+++ b/src/discretization/generate_bc_eqs.jl
@@ -4,27 +4,6 @@
     push!(bceqs, generate_bc_eqs(s, boundaryvalfuncs, boundary, interiormap, indexmap))
 end
 
-function generate_bc_eqs!(bceqs, s::DiscreteSpace{N}, boundaryvalfuncs, interiormap, boundary::PeriodicBoundary) where N
-    # depvarbcmaps will dictate what to replace the variable terms with in the bcs
-    # replace u(t,0) with u₁, etc
-    u_, x_ = getvars(boundary)
-    j = x2i(s, depvar(u_, s), x_)
-    # * Assume that the periodic BC is of the simple form u(t,0) ~ u(t,1)
-    Ioffset = unitindex(N, j)*(length(s, x_) - 1)
-    local disc
-    for u in s.ū
-        if isequal(operation(u), operation(u_))
-            disc =  s.discvars[u]
-            break
-        end
-    end
-
-    push!(bceqs, vec(map(edge(s, boundary, interiormap)) do II
-        disc[II] ~ disc[II + Ioffset]
-    end))
-
-end
-
 function generate_bc_eqs!(bceqs, s::DiscreteSpace, boundaryvalfuncs, interiormap, boundary::InterfaceBoundary)
     isupper(boundary) && return
     u_ = boundary.u

--- a/src/discretization/generate_finite_difference_rules.jl
+++ b/src/discretization/generate_finite_difference_rules.jl
@@ -44,27 +44,27 @@ There are of course more specific schemes that are used to improve stability/spe
 
 Please submit an issue if you know of any special cases which impact stability or accuracy that are not implemented, with links to papers and/or code that demonstrates the special case.
 """
-function generate_finite_difference_rules(II::CartesianIndex, s::DiscreteSpace, depvars, pde::Equation, derivweights::DifferentialDiscretizer, pmap, indexmap)
+function generate_finite_difference_rules(II::CartesianIndex, s::DiscreteSpace, depvars, pde::Equation, derivweights::DifferentialDiscretizer, bmap, indexmap)
 
     terms = split_terms(pde, s.x̄)
 
     # Standard cartesian centered difference scheme
-    central_deriv_rules_cartesian = generate_cartesian_rules(II, s, depvars, derivweights, pmap, indexmap, terms)
+    central_deriv_rules_cartesian = generate_cartesian_rules(II, s, depvars, derivweights, bmap, indexmap, terms)
 
     # Advection rules
     if derivweights.advection_scheme isa UpwindScheme
-        advection_rules = generate_winding_rules(II, s, depvars, derivweights, pmap, indexmap, terms)
+        advection_rules = generate_winding_rules(II, s, depvars, derivweights, bmap, indexmap, terms)
     elseif derivweights.advection_scheme isa WENOScheme
-        advection_rules = generate_WENO_rules(II, s, depvars, derivweights, pmap, indexmap, terms)
+        advection_rules = generate_WENO_rules(II, s, depvars, derivweights, bmap, indexmap, terms)
     else
         error("Unsupported advection scheme $(derivweights.advection_scheme) encountered.")
     end
 
     # Nonlinear laplacian scheme
-    nonlinlap_rules = generate_nonlinlap_rules(II, s, depvars, derivweights, pmap, indexmap, terms)
+    nonlinlap_rules = generate_nonlinlap_rules(II, s, depvars, derivweights, bmap, indexmap, terms)
 
     # Spherical diffusion scheme
-    spherical_diffusion_rules = generate_spherical_diffusion_rules(II, s, depvars, derivweights, pmap, indexmap, split_additive_terms(pde))
+    spherical_diffusion_rules = generate_spherical_diffusion_rules(II, s, depvars, derivweights, bmap, indexmap, split_additive_terms(pde))
 
     return vcat(vec(spherical_diffusion_rules), vec(nonlinlap_rules), vec(central_deriv_rules_cartesian), vec(advection_rules))
 end

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -55,7 +55,7 @@ function get_interface_vars(b, s, j)
 
     N = ndims(u, s)
     I1 = unitindex(N, j)
-    return I1, discu2, l2
+    return I1, discu2, l1, l2
 end
 
 function _wrapinterface(I, s, b::InterfaceBoundary{Val{false}, Val{true}}, j)

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -46,7 +46,7 @@ function wrapinterface(I::RefCartesianIndex{N,Nothing}, s::DiscreteSpace, b::Int
     return _wrapinterface(I.I, s, b, j)
 end
 
-function wrapinterface(I::RefCartesianIndex, s::DiscreteSpace, ::InterfaceBoundary, jx)
+@inline function wrapinterface(I::RefCartesianIndex, s::DiscreteSpace, ::InterfaceBoundary, jx)
     return I
 end
 

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -1,4 +1,4 @@
-struct RefCartesianIndex{N, AType}
+struct RefCartesianIndex{N, AType} <: Base.AbstractCartesianIndex{N}
     I::CartesianIndex{N}
     A::AType
     RefCartesianIndex(I::CartesianIndex{N}, A = nothing) where {N} = new{N, typeof(A)}(I, A)
@@ -14,6 +14,12 @@ function Base.getindex(A::Array, Is::Vector{<:RefCartesianIndex})
     end
 end
 
+Base.:+(I::RefCartesianIndex, J::RefCartesianIndex) = RefCartesianIndex(I.I + J.I, I.A)
+Base.:-(I::RefCartesianIndex, J::RefCartesianIndex) = RefCartesianIndex(I.I - J.I, I.A)
+Base.:+(I::RefCartesianIndex, J::CartesianIndex) = RefCartesianIndex(I.I + J, I.A)
+Base.:-(I::RefCartesianIndex, J::CartesianIndex) = RefCartesianIndex(I.I - J, I.A)
+Base.:+(I::CartesianIndex, J::RefCartesianIndex) = RefCartesianIndex(I + J.I, J.A)
+Base.:-(I::CartesianIndex, J::RefCartesianIndex) = RefCartesianIndex(I - J.I, J.A)
 
 (b::InterfaceBoundary)(I, s, jx) = wrapinterface(I, s, b, jx)
             (b::AbstractBoundary)(I, s, jx) = I

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -16,8 +16,7 @@ end
 
 
 (b::InterfaceBoundary)(I, s, jx) = wrapinterface(I, s, b, jx)
-(b::InterfaceBoundary)(I::RefCartesianIndex, s, jx) = I
-(b::AbstractBoundary)(I, s, jx) = I
+            (b::AbstractBoundary)(I, s, jx) = I
 
 function bwrap(I, bs, s, jx)
     for b in bs
@@ -40,20 +39,16 @@ end
 """
 Allow stencils indexing over periodic boundaries. Index through this function.
 """
-function wrapinterface(I, s, ::PeriodicBoundary, u, jx)
+
+
+function wrapinterface(I::RefCartesianIndex{N,Nothing}, s::DiscreteSpace, b::InterfaceBoundary, jx) where {N}
     j, x = jx
-    return _wrapperiodic(I, ndims(u, s), j, length(s, x))
+    return _wrapinterface(I.I, s, b, j)
 end
 
-function wrapinterface(I, s, b, u, jx)
+function wrapinterface(I::RefCartesianIndex, s::DiscreteSpace, ::InterfaceBoundary, jx)
     return I
 end
-
-
-function wrapinterface(I::RefCartesianIndex, s, ::InterfaceBoundary, u, jx)
-    return I
-end
-
 
 function wrapinterface(I, s, b::InterfaceBoundary, jx)
     j, x = jx
@@ -67,15 +62,20 @@ function get_interface_vars(b, s, j)
     discu2 = s.discvars[depvar(u2, s)]
     l1 = length(s, b.x)
     l2 = length(s, b.x2)
-
     N = ndims(u, s)
     I1 = unitindex(N, j)
     return I1, discu2, l1, l2
 end
 
-function _wrapinterface(I, s, b::InterfaceBoundary{Val(false), Val(true)}, j)
-    I1, discu2, l1, l2 = get_interface_vars(b, s, j)
+function _wrapinterface(I, s, b::InterfaceBoundary{Val{false}(), Val{true}()}, j)
     if I[j] <= 1
+        u = b.u
+        u2 = b.u2
+        discu2 = s.discvars[depvar(u2, s)]
+        l2 = length(s, b.x2)
+        N = ndims(u, s)
+        I1 = unitindex(N, j)
+        # update index
         I = I + (l2 - 1) * I1
         I = RefCartesianIndex(I, discu2)
     else
@@ -83,10 +83,16 @@ function _wrapinterface(I, s, b::InterfaceBoundary{Val(false), Val(true)}, j)
     end
 end
 
-function _wrapinterface(I, s, b::InterfaceBoundary{Val(true),Val(false)}, j)
-    I1, discu2, l1, l2 = get_interface_vars(b, s, j)
+function _wrapinterface(I, s, b::InterfaceBoundary{Val{true}(),Val{false}()}, j)
+    l1 = length(s, b.x)
     if I[j] > l1
-        I = I + (I[j] - 2l1 + 1) * I1
+        u = b.u
+        u2 = b.u2
+        discu2 = s.discvars[depvar(u2, s)]
+        N = ndims(u, s)
+        I1 = unitindex(N, j)
+        # update index
+        I = I + (1 - l1) * I1
         return RefCartesianIndex(I, discu2)
     else
         return RefCartesianIndex(I)
@@ -94,5 +100,5 @@ function _wrapinterface(I, s, b::InterfaceBoundary{Val(true),Val(false)}, j)
 end
 
 function _wrapinterface(I, s, b::InterfaceBoundary{B, B}, j) where B
-    throw(ArgumentError("Interface $(b.eq) joins two variables at the same boundary end, this is not supported. Please post an issue if you need this feature."))
+    throw(ArgumentError("Interface $(b.eq) joins two variables at the same end of the domain, this is not supported. Please post an issue if you need this feature."))
 end

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -4,7 +4,11 @@ struct RefCartesianIndex{N, AType} <:  Base.AbstractCartesianIndex{N}
     RefCartesianIndex(I::CartesianIndex{N}, A::AType) where {N, AType} = new{N, AType}(I, A)
 end
 
-getindex(_, IR::RefCartesianIndex) = A[IR.I]
+Base.getindex(_, IR::RefCartesianIndex) = A[IR.I]
+function Base.checkbounds(::Type{Bool}, A::AbstractArray, i::Union{RefCartesianIndex,AbstractArray{<:RefCartesianIndex}})
+    @inline
+    checkbounds_indices(Bool, axes(A), (getfield.(i, (:I,)),))
+end
 
 (b::InterfaceBoundary)(I, s, jx) = wrapinterface(I, s, b, jx)
 (b::InterfaceBoundary)(I::RefCartesianIndex, s, jx) = I
@@ -58,7 +62,7 @@ function get_interface_vars(b, s, j)
     return I1, discu2, l1, l2
 end
 
-function _wrapinterface(I, s, b::InterfaceBoundary{Val{false}, Val{true}}, j)
+function _wrapinterface(I, s, b::InterfaceBoundary{Val(false), Val(true)}, j)
     I1, discu2, l1, l2 = get_interface_vars(b, s, j)
     if I[j] <= 1
         I = I + (l2 - 1) * I1
@@ -67,7 +71,7 @@ function _wrapinterface(I, s, b::InterfaceBoundary{Val{false}, Val{true}}, j)
     return I
 end
 
-function _wrapinterface(I, s, b::InterfaceBoundary{Val{true},Val{false}}, j)
+function _wrapinterface(I, s, b::InterfaceBoundary{Val(true),Val(false)}, j)
     I1, discu2, l1, l2 = get_interface_vars(b, s, j)
     if I[j] > l1
         I = I + (I[j] - 2l1 + 1) * I1

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -1,4 +1,4 @@
-struct RefCartesianIndex{N, AType}
+struct RefCartesianIndex{N, AType} <:  Base.AbstractCartesianIndex{N}
     I::CartesianIndex{N}
     A::AType
     RefCartesianIndex(I::CartesianIndex{N}, A::AType) where {N, AType} = new{N, AType}(I, A)

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -7,6 +7,15 @@ end
 getindex(_, IR::RefCartesianIndex) = A[IR.I]
 
 (b::InterfaceBoundary)(I, s, jx) = wrapinterface(I, s, b, jx)
+(b::InterfaceBoundary)(I::RefCartesianIndex, s, jx) = I
+(b::AbstractBoundary)(I, s, jx) = I
+
+function bwrap(I, bs, s, jx)
+    for b in bs
+        I = b(I, s, jx)
+    end
+    return I
+end
 
 @inline function _wrapperiodic(I, N, j, l)
     I1 = unitindex(N, j)

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -1,0 +1,72 @@
+struct RefCartesianIndex{N, AType}
+    I::CartesianIndex{N}
+    A::AType
+    RefCartesianIndex(I::CartesianIndex{N}, A::AType) where {N, AType} = new{N, AType}(I, A)
+end
+
+getindex(_, IR::RefCartesianIndex) = A[IR.I]
+
+(b::InterfaceBoundary)(I, s, jx) = wrapinterface(I, s, b, jx)
+
+@inline function _wrapperiodic(I, N, j, l)
+    I1 = unitindex(N, j)
+    # -1 because of the relation u[1] ~ u[end]
+    if I[j] <= 1
+        I = I + I1 * (l - 1)
+    elseif I[j] > l
+        I = I - I1 * (l - 1)
+    end
+    return I
+end
+
+"""
+Allow stencils indexing over periodic boundaries. Index through this function.
+"""
+function wrapinterface(I, s, ::PeriodicBoundary, u, jx)
+    j, x = jx
+    return _wrapperiodic(I, ndims(u, s), j, length(s, x))
+end
+
+function wrapinterface(I, s, ::Val{false}, u, jx)
+    return I
+end
+
+function wrapinterface(I, s, b::InterfaceBoundary, jx)
+    j, x = jx
+
+    return _wrapinterface(I, s, b, j)
+end
+
+function get_interface_vars(b, s, j)
+    u = b.u
+    u2 = b.u2
+    discu2 = s.discvars[depvar(u2, s)]
+    l1 = length(s, b.x)
+    l2 = length(s, b.x2)
+
+    N = ndims(u, s)
+    I1 = unitindex(N, j)
+    return I1, discu2, l2
+end
+
+function _wrapinterface(I, s, b::InterfaceBoundary{Val{false}, Val{true}}, j)
+    I1, discu2, l1, l2 = get_interface_vars(b, s, j)
+    if I[j] <= 1
+        I = I + (l2 - 1) * I1
+        I = RefCartesianIndex(I, discu2)
+    end
+    return I
+end
+
+function _wrapinterface(I, s, b::InterfaceBoundary{Val{true},Val{false}}, j)
+    I1, discu2, l1, l2 = get_interface_vars(b, s, j)
+    if I[j] > l1
+        I = I + (I[j] - 2l1 + 1) * I1
+        I = RefCartesianIndex(I, discu2)
+    end
+    return I
+end
+
+function _wrapinterface(I, s, b::InterfaceBoundary{B, B}, j) where B
+    throw(ArgumentError("Interface $(b.eq) joins two variables at the same boundary end, this is not supported. Please post an issue if you need this feature."))
+end

--- a/src/discretization/schemes/WENO/WENO.jl
+++ b/src/discretization/schemes/WENO/WENO.jl
@@ -84,6 +84,6 @@ end
 """
 This is a catch all ruleset, as such it does not use @rule.
 """
-@inline function generate_WENO_rules(II::CartesianIndex, s::DiscreteSpace, depvars, derivweights::DifferentialDiscretizer, pmap, indexmap, terms)
+@inline function generate_WENO_rules(II::CartesianIndex, s::DiscreteSpace, depvars, derivweights::DifferentialDiscretizer, bcmap, indexmap, terms)
     return reduce(vcat, [[(Differential(x))(u) => weno(Idx(II, s, u, indexmap), s, derivweights.advection_scheme, filter_interfaces(bcmap[operation(u)][x]), (x2i(s, u, x), x), u, s.dxs[x]) for x in params(u, s)] for u in depvars])
 end

--- a/src/discretization/schemes/WENO/WENO.jl
+++ b/src/discretization/schemes/WENO/WENO.jl
@@ -6,7 +6,7 @@ Specified in https://repository.library.brown.edu/studio/item/bdr:297524/PDF/ (P
 
 Implementation *heavily* inspired by https://github.com/ranocha/HyperbolicDiffEq.jl/blob/84c2d882e0c8956457c7d662bf7f18e3c27cfa3d/src/finite_volumes/weno_jiang_shu.jl by H. Ranocha.
 """
-function weno(II::CartesianIndex, s::DiscreteSpace, wenoscheme::WENOScheme, b, jx, u, dx::Number)
+function weno(II::CartesianIndex, s::DiscreteSpace, wenoscheme::WENOScheme, bs, jx, u, dx::Number)
     j, x = jx
     ε = wenoscheme.epsilon
 
@@ -14,10 +14,10 @@ function weno(II::CartesianIndex, s::DiscreteSpace, wenoscheme::WENOScheme, b, j
 
     udisc = s.discvars[u]
 
-    Im2 = wrapperiodic(II - 2I1, s, b, u, jx)
-    Im1 = wrapperiodic(II - I1, s, b, u, jx)
-    Ip1 = wrapperiodic(II + I1, s, b, u, jx)
-    Ip2 = wrapperiodic(II + 2I1, s, b, u, jx)
+    Im2 = bwrap(II - 2I1, bs, s, jx)
+    Im1 = bwrap(II - I1, bs, s, jx)
+    Ip1 = bwrap(II + I1, bs, s, jx)
+    Ip2 = bwrap(II + 2I1, bs, s, jx)
     is = map(I -> I[j], [Im2, Im1, Ip1, Ip2])
     for i in is
         if i < 1
@@ -85,5 +85,5 @@ end
 This is a catch all ruleset, as such it does not use @rule.
 """
 @inline function generate_WENO_rules(II::CartesianIndex, s::DiscreteSpace, depvars, derivweights::DifferentialDiscretizer, pmap, indexmap, terms)
-    return reduce(vcat, [[(Differential(x))(u) => weno(Idx(II, s, u, indexmap), s, derivweights.advection_scheme, pmap.map[operation(u)][x], (x2i(s, u, x), x), u, s.dxs[x]) for x in params(u, s)] for u in depvars])
+    return reduce(vcat, [[(Differential(x))(u) => weno(Idx(II, s, u, indexmap), s, derivweights.advection_scheme, filter_interfaces(bcmap[operation(u)][x]), (x2i(s, u, x), x), u, s.dxs[x]) for x in params(u, s)] for u in depvars])
 end

--- a/src/discretization/schemes/centered_difference/centered_difference.jl
+++ b/src/discretization/schemes/centered_difference/centered_difference.jl
@@ -45,7 +45,7 @@ function central_difference(D::DerivativeOperator{T,N,Wind,DX}, II, s, bs, jx, u
         Itap = [II + (i + offset) * I1 for i in (-D.boundary_stencil_length+1):1:0]
     else
         weights = D.stencil_coefs[II[j]-D.boundary_point_count]
-        Itap = [wrapperiodic(II + i * I1, s, b, u, jx) for i in half_range(D.stencil_length)]
+        Itap = [II + i * I1 for i in half_range(D.stencil_length)]
     end
     # Tap points of the stencil, this uses boundary_point_count as this is equal to half the stencil size, which is what we want.
 

--- a/src/discretization/schemes/centered_difference/centered_difference.jl
+++ b/src/discretization/schemes/centered_difference/centered_difference.jl
@@ -2,43 +2,44 @@
 Performs a centered difference in `x` centered at index `II` of `u`
 ufunc is a function that returns the correct discretization indexed at Itap, it is designed this way to allow for central differences of arbitrary expressions which may be needed in some schemes
 """
-function central_difference(D::DerivativeOperator{T,N,Wind,DX}, II, s, b, jx, u, ufunc) where {T,N,Wind,DX<:Number}
+function central_difference(D::DerivativeOperator{T,N,Wind,DX}, II, s, bs, jx, u, ufunc) where {T,N,Wind,DX<:Number}
     j, x = jx
     ndims(u, s) == 0 && return Num(0)
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
     # offset is important due to boundary proximity
+    haslower, hasupper = haslowerupper(bs)
 
-    if (II[j] <= D.boundary_point_count) & (b isa Val{false})
+    if (II[j] <= D.boundary_point_count) & !haslower
         weights = D.low_boundary_coefs[II[j]]
         offset = 1 - II[j]
         Itap = [II + (i + offset) * I1 for i in 0:(D.boundary_stencil_length-1)]
-    elseif (II[j] > (length(s, x) - D.boundary_point_count)) & (b isa Val{false})
+    elseif (II[j] > (length(s, x) - D.boundary_point_count)) & !hasupper
         weights = D.high_boundary_coefs[length(s, x)-II[j]+1]
         offset = length(s, x) - II[j]
         Itap = [II + (i + offset) * I1 for i in (-D.boundary_stencil_length+1):1:0]
     else
         weights = D.stencil_coefs
-        Itap = [wrapperiodic(II + i * I1, s, b, u, jx) for i in half_range(D.stencil_length)]
+        Itap = [bwrap(II + i * I1, bs, s, jx) for i in half_range(D.stencil_length)]
     end
     # Tap points of the stencil, this uses boundary_point_count as this is equal to half the stencil size, which is what we want.
 
     return dot(weights, ufunc(u, Itap, x))
 end
 
-function central_difference(D::DerivativeOperator{T,N,Wind,DX}, II, s, b, jx, u, ufunc) where {T,N,Wind,DX<:AbstractVector}
+function central_difference(D::DerivativeOperator{T,N,Wind,DX}, II, s, bs, jx, u, ufunc) where {T,N,Wind,DX<:AbstractVector}
     j, x = jx
-    @assert b isa Val{false} "Periodic boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
+    @assert length(bs) == 0 "Interface boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
     ndims(u, s) == 0 && return Num(0)
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
     # offset is important due to boundary proximity
 
-    if (II[j] <= D.boundary_point_count) & (b isa Val{false})
+    if (II[j] <= D.boundary_point_count)
         weights = D.low_boundary_coefs[II[j]]
         offset = 1 - II[j]
         Itap = [II + (i + offset) * I1 for i in 0:(D.boundary_stencil_length-1)]
-    elseif (II[j] > (length(s, x) - D.boundary_point_count)) & (b isa Val{false})
+    elseif (II[j] > (length(s, x) - D.boundary_point_count))
         weights = D.high_boundary_coefs[length(s, x)-II[j]+1]
         offset = length(s, x) - II[j]
         Itap = [II + (i + offset) * I1 for i in (-D.boundary_stencil_length+1):1:0]
@@ -54,9 +55,9 @@ end
 """
 This is a catch all ruleset, as such it does not use @rule. Any even ordered derivative may be adequately approximated by these.
 """
-@inline function generate_cartesian_rules(II::CartesianIndex, s::DiscreteSpace, depvars, derivweights::DifferentialDiscretizer, pmap, indexmap, terms)
+@inline function generate_cartesian_rules(II::CartesianIndex, s::DiscreteSpace, depvars, derivweights::DifferentialDiscretizer, bcmap, indexmap, terms)
     central_ufunc(u, I, x) = s.discvars[u][I]
-    return reduce(vcat, [reduce(vcat, [[(Differential(x)^d)(u) => central_difference(derivweights.map[Differential(x)^d], Idx(II, s, u, indexmap), s, pmap.map[operation(u)][x], (x2i(s, u, x), x), u, central_ufunc) for d in (
+    return reduce(vcat, [reduce(vcat, [[(Differential(x)^d)(u) => central_difference(derivweights.map[Differential(x)^d], Idx(II, s, u, indexmap), s, filter_interfaces(bcmap[operation(u)][x]), (x2i(s, u, x), x), u, central_ufunc) for d in (
         let orders = derivweights.orders[x]
             orders[iseven.(orders)]
         end

--- a/src/discretization/schemes/centered_difference/centered_difference.jl
+++ b/src/discretization/schemes/centered_difference/centered_difference.jl
@@ -8,7 +8,7 @@ function central_difference(D::DerivativeOperator{T,N,Wind,DX}, II, s, bs, jx, u
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
     # offset is important due to boundary proximity
-    haslower, hasupper = haslowerupper(bs)
+    haslower, hasupper = haslowerupper(bs, x)
 
     if (II[j] <= D.boundary_point_count) & !haslower
         weights = D.low_boundary_coefs[II[j]]

--- a/src/discretization/schemes/half_offset_centred_difference.jl
+++ b/src/discretization/schemes/half_offset_centred_difference.jl
@@ -6,10 +6,9 @@ TODO: consider refactoring this to harmonize with centered difference
 
 Each index corresponds to the weights and index for the derivative at index i+1/2
 """
-function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::CartesianIndex, s::DiscreteSpace, bs, u, jx, len=0) where {T,N,Wind,DX<:Number}
+function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::Base.AbstractCartesianIndex, s::DiscreteSpace, bs, u, jx, len=0) where {T,N,Wind,DX<:Number}
     j, x = jx
     len = len == 0 ? length(s, x) : len
-    @assert II[j] != length(s, x)
     haslower, hasupper = haslowerupper(bs)
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)

--- a/src/discretization/schemes/half_offset_centred_difference.jl
+++ b/src/discretization/schemes/half_offset_centred_difference.jl
@@ -31,7 +31,7 @@ function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX},
     return (weights, Itap)
 end
 
-function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::CartesianIndex, s::DiscreteSpace, bs, u, jx, len=0) where {T,N,Wind,DX<:AbstractVector}
+function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::Base.AbstractCartesianIndex, s::DiscreteSpace, bs, u, jx, len=0) where {T,N,Wind,DX<:AbstractVector}
     j, x = jx
     @assert length(bs) == 0 "Periodic boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
     len = len == 0 ? length(s, x) : len

--- a/src/discretization/schemes/half_offset_centred_difference.jl
+++ b/src/discretization/schemes/half_offset_centred_difference.jl
@@ -9,7 +9,7 @@ Each index corresponds to the weights and index for the derivative at index i+1/
 function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::Base.AbstractCartesianIndex, s::DiscreteSpace, bs, u, jx, len=0) where {T,N,Wind,DX<:Number}
     j, x = jx
     len = len == 0 ? length(s, x) : len
-    haslower, hasupper = haslowerupper(bs)
+    haslower, hasupper = haslowerupper(bs, x)
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
     # offset is important due to boundary proximity
@@ -24,7 +24,7 @@ function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX},
         Itap = [II + (i + offset) * I1 for i in (-D.boundary_stencil_length+1):0]
     else
         weights = D.stencil_coefs
-        Itap = [bwrap(II + i * I1, bs, s, jx) for i in (1-div(D.stencil_length, 2)):(div(D.stencil_length, 2))]
+        Itap = [II + i * I1 for i in (1-div(D.stencil_length, 2)):(div(D.stencil_length, 2))]
     end
 
     return (weights, Itap)

--- a/src/discretization/schemes/half_offset_centred_difference.jl
+++ b/src/discretization/schemes/half_offset_centred_difference.jl
@@ -6,34 +6,34 @@ TODO: consider refactoring this to harmonize with centered difference
 
 Each index corresponds to the weights and index for the derivative at index i+1/2
 """
-function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::CartesianIndex, s::DiscreteSpace, b, u, jx, len=0) where {T,N,Wind,DX<:Number}
+function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::CartesianIndex, s::DiscreteSpace, bs, u, jx, len=0) where {T,N,Wind,DX<:Number}
     j, x = jx
     len = len == 0 ? length(s, x) : len
     @assert II[j] != length(s, x)
-
+    haslower, hasupper = haslowerupper(bs)
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
     # offset is important due to boundary proximity
 
-    if (II[j] <= D.boundary_point_count) & (b isa Val{false})
+    if (II[j] <= D.boundary_point_count) & !haslower
         weights = D.low_boundary_coefs[II[j]]
         offset = 1 - II[j]
         Itap = [II + (i + offset) * I1 for i in 0:(D.boundary_stencil_length-1)]
-    elseif (II[j] > (len - D.boundary_point_count)) & (b isa Val{false})
+    elseif (II[j] > (len - D.boundary_point_count)) & !hasupper
         weights = D.high_boundary_coefs[len-II[j]]
         offset = len - II[j]
         Itap = [II + (i + offset) * I1 for i in (-D.boundary_stencil_length+1):0]
     else
         weights = D.stencil_coefs
-        Itap = [wrapperiodic(II + i * I1, s, b, u, jx) for i in (1-div(D.stencil_length, 2)):(div(D.stencil_length, 2))]
+        Itap = [bwrap(II + i * I1, bs, s, jx) for i in (1-div(D.stencil_length, 2)):(div(D.stencil_length, 2))]
     end
 
     return (weights, Itap)
 end
 
-function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::CartesianIndex, s::DiscreteSpace, b, u, jx, len=0) where {T,N,Wind,DX<:AbstractVector}
+function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX}, II::CartesianIndex, s::DiscreteSpace, bs, u, jx, len=0) where {T,N,Wind,DX<:AbstractVector}
     j, x = jx
-    @assert b isa Val{false} "Periodic boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
+    @assert length(bs) == 0 "Periodic boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
     len = len == 0 ? length(s, x) : len
     @assert II[j] != length(s, x)
 
@@ -58,9 +58,9 @@ function get_half_offset_weights_and_stencil(D::DerivativeOperator{T,N,Wind,DX},
 end
 
 # i is the index of the offset, assuming that there is one precalculated set of weights for each offset required for a first order finite difference
-function half_offset_centered_difference(D, II, s, b, jx, u, ufunc)
+function half_offset_centered_difference(D, II, s, bs, jx, u, ufunc)
     ndims(u, s) == 0 && return Num(0)
     j, x = jx
-    weights, Itap = get_half_offset_weights_and_stencil(D, II, s, b, u, jx)
+    weights, Itap = get_half_offset_weights_and_stencil(D, II, s, bs, u, jx)
     return dot(weights, ufunc(u, Itap, x))
 end

--- a/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
+++ b/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
@@ -41,9 +41,9 @@ function cartesian_nonlinear_laplacian(expr, II, derivweights, s::DiscreteSpace,
     #* Need to see how to handle this with interface boundaries
     haslower, hasupper = haslowerupper(bs)
     if (haslower & II[j] < div(length(s, x), 2))
-        outerweights, outerstencil = get_half_offset_weights_and_stencil(D_inner, I, s, bs, u, jx)
+        outerweights, outerstencil = get_half_offset_weights_and_stencil(D_inner, II, s, bs, u, jx)
     elseif (hasupper & II[j] > div(length(s, x), 2))
-        outerweights, outerstencil = get_half_offset_weights_and_stencil(D_inner, I, s, bs, u, jx)
+        outerweights, outerstencil = get_half_offset_weights_and_stencil(D_inner, II, s, bs, u, jx)
     else
         cliplen = length(s, x) - 1
         outerweights, outerstencil = get_half_offset_weights_and_stencil(D_outer, II - unitindex(N, j), s, bs, u, jx, cliplen)

--- a/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
+++ b/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
@@ -40,9 +40,9 @@ function cartesian_nonlinear_laplacian(expr, II, derivweights, s::DiscreteSpace,
     # Get the outer weights and stencil. clip() essentially removes a point from either end of the grid, for this reason this function is only defined on the interior, not in bcs
     #* Need to see how to handle this with interface boundaries
     haslower, hasupper = haslowerupper(bs)
-    if (haslower & II[j] < div(length(s, x), 2))
+    if (haslower & (II[j] < div(length(s, x), 2)))
         outerweights, outerstencil = get_half_offset_weights_and_stencil(D_inner, II, s, bs, u, jx)
-    elseif (hasupper & II[j] > div(length(s, x), 2))
+    elseif (hasupper & (II[j] > div(length(s, x), 2)))
         outerweights, outerstencil = get_half_offset_weights_and_stencil(D_inner, II, s, bs, u, jx)
     else
         cliplen = length(s, x) - 1

--- a/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
+++ b/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
@@ -26,10 +26,11 @@ where `finitediff(u, i)` is the finite difference at the interpolated point `i` 
 
 And so on.
 """
-function cartesian_nonlinear_laplacian(expr, II, derivweights, s::DiscreteSpace{N}, b, depvars, x, u) where {N}
+function cartesian_nonlinear_laplacian(expr, II, derivweights, s::DiscreteSpace, b, depvars, x, u)
     # Based on the paper https://web.mit.edu/braatzgroup/analysis_of_finite_difference_discretization_schemes_for_diffusion_in_spheres_with_variable_diffusivity.pdf
     # See scheme 1, namely the term without the 1/r dependence. See also #354 and #371 in DiffEqOperators, the previous home of this package.
-    ndims(u, s) == 0 && return Num(0)
+    N = ndims(u, s)
+    N == 0 && return Num(0)
     jx = j, x = (x2i(s, u, x), x)
     @assert II[j] != 1 "The nonlinear laplacian is only defined on the interior of the grid, it is unsupported in boundary conditions."
     @assert II[j] != length(s, x) "The nonlinear laplacian is only defined on the interior of the grid, it is unsupported in boundary conditions."

--- a/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
+++ b/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
@@ -49,13 +49,6 @@ function cartesian_nonlinear_laplacian(expr, II, derivweights, s::DiscreteSpace,
     # Get the correct weights and stencils for this II
     inner_deriv_weights_and_stencil = [get_half_offset_weights_and_stencil(D_inner, I, s, bs, u, jx) for I in outerstencil]
     interp_weights_and_stencil = [get_half_offset_weights_and_stencil(inner_interpolater, I, s, bs, u, jx) for I in outerstencil]
-    @show u
-    @show II
-    @show bs
-    @show haslowerupper(bs)
-    @show inner_deriv_weights_and_stencil
-    @show interp_weights_and_stencil
-    @show outerweights, outerstencil
 
     # map variables to symbolically inerpolated/extrapolated expressions
     map_vars_to_interpolated(stencil, weights) = [v => dot(weights, s.discvars[v][interface_wrap(stencil)]) for v in depvars]

--- a/src/discretization/schemes/upwind_difference/upwind_difference.jl
+++ b/src/discretization/schemes/upwind_difference/upwind_difference.jl
@@ -1,7 +1,7 @@
 @inline function _upwind_difference(D::DerivativeOperator{T,N,Wind,DX}, II, s, bs, ispositive, u, jx) where {T,N,Wind,DX<:Number}
     j, x = jx
     I1 = unitindex(ndims(u, s), j)
-    haslower, hasupper = haslowerupper(bs)
+    haslower, hasupper = haslowerupper(bs, x)
     if !ispositive
         if (II[j] > (length(s, x) - D.boundary_point_count)) & !hasupper
             weights = D.high_boundary_coefs[length(s, x)-II[j]+1]

--- a/src/discretization/schemes/upwind_difference/upwind_difference.jl
+++ b/src/discretization/schemes/upwind_difference/upwind_difference.jl
@@ -72,8 +72,8 @@ function upwind_difference(expr, d::Int, II::CartesianIndex, s::DiscreteSpace, b
     # TODO: Allow derivatives in expr
     expr = substitute(expr, valmaps(s, u, depvars, Idx(II, s, depvar(u, s), indexmap), indexmap))
     IfElse.ifelse(expr > 0,
-        expr * upwind_difference(d, II, s, b, derivweights, (j, x), u, central_ufunc, true),
-        expr * upwind_difference(d, II, s, b, derivweights, (j, x), u, central_ufunc, false))
+        expr * upwind_difference(d, II, s, bs, derivweights, (j, x), u, central_ufunc, true),
+        expr * upwind_difference(d, II, s, bs, derivweights, (j, x), u, central_ufunc, false))
 end
 
 @inline function generate_winding_rules(II::CartesianIndex, s::DiscreteSpace, depvars, derivweights::DifferentialDiscretizer, bcmap, indexmap, terms)

--- a/src/interface/solution/plot_utils.jl
+++ b/src/interface/solution/plot_utils.jl
@@ -1,0 +1,25 @@
+function quick_animate(sol::SciMLBase.PDETimeseriesSolution, u)
+    solu = sol[u]
+    s = sol.disc_data.discretespace
+
+    @assert ndims(solu) == 2 "Only 2D (1 space, 1 time) solutions are supported for animation."
+
+    t = s.time
+    discx̄ = map(remove(arguments(u), t)) do x
+        sol[x]
+    end
+
+    findfirst(isequal(t), arguments(u)) == 1 ? false : true
+
+    anim = @animate for i in 1:length(sol.t)
+        indices = map(arguments(u)) do x
+            if isequal(t, x)
+                i
+            else
+                Colon()
+            end
+        end
+        plot(discx̄..., solu[indices...])
+    end
+    return anim
+end

--- a/src/scalar_discretization.jl
+++ b/src/scalar_discretization.jl
@@ -1,4 +1,4 @@
-function discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap, depvars, s, derivweights, indexmap, pmap::PeriodicMap{hasperiodic}) where {hasperiodic}
+function discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap, depvars, s, derivweights, indexmap)
     # Handle boundary values appearing in the equation by creating functions that map each point on the interior to the correct replacement rule
     # Generate replacement rule gen closures for the boundary values like u(t, 1)
     boundaryvalfuncs = generate_boundary_val_funcs(s, depvars, bcmap, indexmap, derivweights)
@@ -9,7 +9,7 @@ function discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap, dep
         generate_bc_eqs!(bceqs, s, boundaryvalfuncs, interiormap, boundary)
     end
     # Generate extrapolation eqs
-    generate_extrap_eqs!(bceqs, pde, eqvar, s, derivweights, interiormap, bcmap, pmap)
+    generate_extrap_eqs!(bceqs, pde, eqvar, s, derivweights, interiormap, bcmap)
 
     # Set invalid corner points to zero
     generate_corner_eqs!(bceqs, s, interiormap, ndims(s.discvars[eqvar]), eqvar)

--- a/src/scalar_discretization.jl
+++ b/src/scalar_discretization.jl
@@ -18,7 +18,7 @@ function discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap, dep
     # Generate the discrete form ODEs for the interior
     eqs = vec(map(interior) do II
         boundaryrules = mapreduce(f -> f(II), vcat, boundaryvalfuncs)
-        rules = vcat(generate_finite_difference_rules(II, s, depvars, pde, derivweights, pmap, indexmap), boundaryrules, valmaps(s, eqvar, depvars, II, indexmap))
+        rules = vcat(generate_finite_difference_rules(II, s, depvars, pde, derivweights, bcmap, indexmap), boundaryrules, valmaps(s, eqvar, depvars, II, indexmap))
         try
             substitute(pde.lhs, rules) ~ substitute(pde.rhs, rules)
         catch e

--- a/src/scalar_discretization.jl
+++ b/src/scalar_discretization.jl
@@ -9,7 +9,7 @@ function discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap, dep
         generate_bc_eqs!(bceqs, s, boundaryvalfuncs, interiormap, boundary)
     end
     # Generate extrapolation eqs
-    generate_extrap_eqs!(bceqs, pde, eqvar, s, derivweights, interiormap, pmap)
+    generate_extrap_eqs!(bceqs, pde, eqvar, s, derivweights, interiormap, bcmap, pmap)
 
     # Set invalid corner points to zero
     generate_corner_eqs!(bceqs, s, interiormap, ndims(s.discvars[eqvar]), eqvar)

--- a/src/scalar_discretization.jl
+++ b/src/scalar_discretization.jl
@@ -15,6 +15,7 @@ function discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap, dep
     generate_corner_eqs!(bceqs, s, interiormap, ndims(s.discvars[eqvar]), eqvar)
     # Extract Interior
     interior = interiormap.I[pde]
+
     # Generate the discrete form ODEs for the interior
     eqs = vec(map(interior) do II
         boundaryrules = mapreduce(f -> f(II), vcat, boundaryvalfuncs)

--- a/src/system_parsing/bcs/parse_boundaries.jl
+++ b/src/system_parsing/bcs/parse_boundaries.jl
@@ -6,7 +6,7 @@ abstract type AbstractBoundary end
 
 abstract type AbstractTruncatingBoundary <: AbstractBoundary end
 
-abstract type AbstractInterfaceBooundary <: AbstractTruncatingBoundary end
+abstract type AbstractInterfaceBoundary <: AbstractTruncatingBoundary end
 
 struct LowerBoundary <: AbstractTruncatingBoundary
     u

--- a/src/system_parsing/bcs/parse_boundaries.jl
+++ b/src/system_parsing/bcs/parse_boundaries.jl
@@ -91,7 +91,7 @@ getvars(b::AbstractBoundary) = (b.u, b.x)
 @inline function isperiodic(bmps, u, x)
     if !isempty(bmps[operation(u)][x])
         # Being explicit hoping the compiler will optimize this away
-        if all(haslowerupper(filter_interfaces(bmps[operation(u)][x])))
+        if all(haslowerupper(filter_interfaces(bmps[operation(u)][x]), x))
             return Val(true)
         else
             return Val(false)
@@ -125,14 +125,16 @@ end
 
 filter_interfaces(bs) = filter(b -> b isa InterfaceBoundary, bs)
 
-function haslowerupper(bs)
+function haslowerupper(bs, x)
     haslower = false
     hasupper = false
     for b in filter_interfaces(bs)
-        if isupper(b)
-            hasupper = true
-        else
-            haslower = true
+        if isequal(b.x, x)
+            if isupper(b)
+                hasupper = true
+            else
+                haslower = true
+            end
         end
     end
     return haslower, hasupper

--- a/src/system_parsing/bcs/parse_boundaries.jl
+++ b/src/system_parsing/bcs/parse_boundaries.jl
@@ -220,9 +220,9 @@ function parse_bcs(bcs, v::VariableMap, orders)
                 for term_ in setdiff(terms, [term]), r_ in reduce(vcat, reduce(vcat, collect.(values.(collect(values(upper_boundary_rules))))))
                     if subsmatch(term_, r_)
                         u__, x__, order__ = r_.second
-                        @assert ndims(u_, s) == ndims(u__, s) "Invalid Interface Boundary $bc: Dependent variables $(u_) and $(u__) have different numbers of dimensions."
-                        boundary = (InterfaceBoundary{Val(false),Val(true)}(u_, u__, x_, x__, u_ ~ u__),
-                            InterfaceBoundary{Val(true),Val(false)}(u_, u__, x_, x__, u_ ~ u__))
+                        @assert ndims(u_, v) == ndims(u__, v) "Invalid Interface Boundary $bc: Dependent variables $(u_) and $(u__) have different numbers of dimensions."
+                        boundary = (InterfaceBoundary{Val(false),Val(true)}(u_, u__, x_, x__, bc),
+                            InterfaceBoundary{Val(true),Val(false)}(u_, u__, x_, x__, bc))
                     end
                 end
 

--- a/src/system_parsing/bcs/parse_boundaries.jl
+++ b/src/system_parsing/bcs/parse_boundaries.jl
@@ -243,7 +243,7 @@ function parse_bcs(bcs, v::VariableMap, orders)
         if isinterface
             if all(==(0), interface_orders)
                 boundary = (InterfaceBoundary{Val(false), Val(true)}(u_, u__, x_, x__, bc),
-                            InterfaceBoundary{Val(true), Val(false)}(u_, u__, x_, x__, bc))
+                            InterfaceBoundary{Val(true), Val(false)}(u__, u_, x__, x_, bc))
             else
                 boundary = nothing
             end

--- a/src/system_parsing/bcs/parse_boundaries.jl
+++ b/src/system_parsing/bcs/parse_boundaries.jl
@@ -57,8 +57,10 @@ struct InterfaceBoundary{IsUpper_u,IsUpper_u2} <: AbstractBoundary
     eq
 end
 
-function isequal(i1::InterfaceBoundary, i2::InterfaceBoundary)
-    return isequal(i1.u, i2.u) && isequal(i1.u2, i2.u2) && isequal(i1.x, i2.x) && isequal(i1.x2, i2.x2)
+function Base.isequal(i1::InterfaceBoundary, i2::InterfaceBoundary)
+    front = (isequal(i1.u, i2.u) & isequal(i1.u2, i2.u2) & isequal(i1.x, i2.x) & isequal(i1.x2, i2.x2))
+    back = (isequal(i1.u, i2.u2) & isequal(i1.u2, i2.u) & isequal(i1.x, i2.x2) & isequal(i1.x2, i2.x))
+    return front | back
 end
 
 getvars(b::AbstractBoundary) = (b.u, b.x)
@@ -113,7 +115,7 @@ function haslowerupper(bs)
     return haslower, hasupper
 end
 
-has_interfaces(bmps) = any(b - > isa InterfaceBoundary, reduce(vcat, reduce(vcat, collect.(values.(collect(values(boundarymap)))))))
+has_interfaces(bmps) = any(b -> b isa InterfaceBoundary, reduce(vcat, reduce(vcat, collect.(values.(collect(values(bmps)))))))
 
 @inline function clip_interior!!(lower, upper, s, b::AbstractBoundary)
     # This x2i is correct

--- a/src/system_parsing/bcs/parse_boundaries.jl
+++ b/src/system_parsing/bcs/parse_boundaries.jl
@@ -235,6 +235,8 @@ function parse_bcs(bcs, v::VariableMap, orders)
                 # Handle flux condition at interface
             end
         end
+        # If this is a condition on flux at an interface, leave it to become an upper boundary
+        # Else if it is a simple interface, make interface boundaries
         if isinterface
             if all(==(0), interface_orders)
                 boundary = (InterfaceBoundary{Val(false), Val(true)}(u_, u__, x_, x__, bc),

--- a/src/system_parsing/interior_map.jl
+++ b/src/system_parsing/interior_map.jl
@@ -42,10 +42,10 @@ function InteriorMap(pdes, boundarymap, s::DiscreteSpace{N,M}, discretization, p
         pdeorders = Dict(map(x -> x => d_orders(x, [pde]), s.x̄))
 
         # Add ghost points to pad stencil extents
-        stencil_extents = calculate_stencil_extents(s, u, discretization, pdeorders, pmap)
-        push!(extents, pde => stencil_extents)
-        lower = [max(e, l) for (e, l) in zip(stencil_extents, lower)]
-        upper = [max(e, u) for (e, u) in zip(stencil_extents, upper)]
+        lowerextents, upperextents = calculate_stencil_extents(s, u, discretization, pdeorders, boundarymap)
+        push!(extents, pde => (lowerextents, upperextents))
+        lower = [max(e, l) for (e, l) in zip(lowerextents, lower)]
+        upper = [max(e, u) for (e, u) in zip(upperextents, upper)]
 
         # Don't update this x2i, it is correct.
         pde => generate_interior(lower, upper, u, s, discretization)
@@ -66,25 +66,27 @@ function generate_interior(lower, upper, u, s, disc::MOLFiniteDifference{G, D}) 
     return [(1+lower[x2i(s, u, x)], length(s.grid[x])-upper[x2i(s, u, x)]) for x in args]
 end
 
-function calculate_stencil_extents(s, u, discretization, orders, pmap)
+function calculate_stencil_extents(s, u, discretization, orders, bcmap)
     aorder = discretization.approx_order
     advection_scheme = discretization.advection_scheme
 
     args = remove(arguments(u), s.time)
-    extents = zeros(Int, length(args))
+    lowerextents = zeros(Int, length(args))
+    upperextents = zeros(Int, length(args))
+
     for (j,x) in enumerate(args)
         # Skip if periodic in x
-        filter_interfaces(bcmap[operation(u)][x]) isa Val{true} && continue
-        for dorder in orders[x]
-            if isodd(dorder)
-                extents[j] = max(extents[j], extent(advection_scheme, dorder))
-            else
-                #TODO: add scheme types for even order derivatives
-                extents[j] = max(extents[j], 0)
+        haslower, hasupper = haslowerupper(filter_interfaces(bcmap[operation(u)][x]))
+        for dorder in filter(isodd, orders[x])
+            if !haslower
+                lowerextents[j] = max(lowerextents[j], extent(advection_scheme, dorder))
+            end
+            if !hasupper
+                upperextents[j] = max(upperextents[j], extent(advection_scheme, dorder))
             end
         end
     end
-    return extents
+    return lowerextents, upperextents
 end
 
 function buildmatrix(pdes, s::DiscreteSpace{N,M}) where {N,M}

--- a/src/system_parsing/interior_map.jl
+++ b/src/system_parsing/interior_map.jl
@@ -15,7 +15,7 @@ end
 # then we assign v to it because u is already assigned somewhere else.
 # and use the interior based on the assignment
 
-function InteriorMap(pdes, boundarymap, s::DiscreteSpace{N,M}, discretization, pmap) where {N,M}
+function InteriorMap(pdes, boundarymap, s::DiscreteSpace{N,M}, discretization) where {N,M}
     @assert length(pdes) == M "There must be the same number of equations and unknowns, got $(length(pdes)) equations and $(M) unknowns"
     m = buildmatrix(pdes, s)
     varmap = Dict(build_variable_mapping(m, s.ū, pdes))

--- a/src/system_parsing/interior_map.jl
+++ b/src/system_parsing/interior_map.jl
@@ -74,7 +74,7 @@ function calculate_stencil_extents(s, u, discretization, orders, pmap)
     extents = zeros(Int, length(args))
     for (j,x) in enumerate(args)
         # Skip if periodic in x
-        pmap.map[operation(u)][x] isa Val{true} && continue
+        filter_interfaces(bcmap[operation(u)][x]) isa Val{true} && continue
         for dorder in orders[x]
             if isodd(dorder)
                 extents[j] = max(extents[j], extent(advection_scheme, dorder))

--- a/src/system_parsing/interior_map.jl
+++ b/src/system_parsing/interior_map.jl
@@ -76,7 +76,7 @@ function calculate_stencil_extents(s, u, discretization, orders, bcmap)
 
     for (j,x) in enumerate(args)
         # Skip if periodic in x
-        haslower, hasupper = haslowerupper(filter_interfaces(bcmap[operation(u)][x]))
+        haslower, hasupper = haslowerupper(filter_interfaces(bcmap[operation(u)][x]), x)
         for dorder in filter(isodd, orders[x])
             if !haslower
                 lowerextents[j] = max(lowerextents[j], extent(advection_scheme, dorder))

--- a/src/system_parsing/pde_system_transformation.jl
+++ b/src/system_parsing/pde_system_transformation.jl
@@ -101,8 +101,12 @@ function nonlinlap_check(term, differential)
             end
 
             is = findall(args) do arg
-                op = operation(arg)
-                op isa Differential && isequal(op.x, differential.x)
+                if istree(arg)
+                    op = operation(arg)
+                    op isa Differential && isequal(op.x, differential.x)
+                else
+                    false
+                end
             end
             if length(is) == 1
                 i = first(is)

--- a/src/system_parsing/pde_system_transformation.jl
+++ b/src/system_parsing/pde_system_transformation.jl
@@ -31,7 +31,7 @@ function transform_pde_system!(v, boundarymap, sys::PDESystem)
     end
 
     sys = PDESystem(eqs, bcs, sys.domain, sys.ivs, Num.(v.ū), sys.ps, name=sys.name)
-    return sys, pmap
+    return sys
 end
 
 function cardinalize_eqs!(pdesys)

--- a/src/system_parsing/pde_system_transformation.jl
+++ b/src/system_parsing/pde_system_transformation.jl
@@ -224,6 +224,9 @@ function create_aux_variable!(eqs, bcs, boundarymap, pmap, v, term)
                 push!(newbcs, PeriodicBoundary(newop(args1...), iv, newop(args1...) ~ newop(args2...)))
                 continue
             end
+            interfaces = filter_interfaces(boundarymap[operation(dv)][iv])
+            @assert length(interfaces) == 0 "Interface BCs like $(interfaces[1].eq) are not yet supported in conjunction with system transformation, please transform manually if needed and set `should_transform=false` in the discretization. If you need this feature, please open an issue on GitHub."
+
             boundaries = boundarymap[dv][iv]
             length(bcs) == 0 && continue
 

--- a/src/system_parsing/variable_map.jl
+++ b/src/system_parsing/variable_map.jl
@@ -42,6 +42,8 @@ end
 
 params(u, v::VariableMap) = remove(v.args[operation(u)], v.time)
 
+Base.ndims(u, v::VariableMap) = length(params(u, v))
+
 all_ivs(v::VariableMap) = v.time === nothing ? v.x̄ : v.x̄ ∪ [v.time]
 
 all_params(u, v::VariableMap) = v.args[operation(u)]

--- a/test/components/solution_interface.jl
+++ b/test/components/solution_interface.jl
@@ -1,4 +1,3 @@
-# 1d wave equation
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, NonlinearSolve, DomainSets
 using ModelingToolkit: Differential
@@ -50,7 +49,7 @@ using ModelingToolkit: Differential
     for i in 1:length(sol.t)
         for j in 1:9
             for k in 1:9
-                traditional_sol[i, j, k] = solu[j, k][i]
+                traditional_sol[i, j, k] = solu[i][j, k]
             end
         end
     end
@@ -58,7 +57,7 @@ using ModelingToolkit: Differential
 
     @test sol[u(t, x, y)] == traditional_sol
 
-    @test sol(pi / 2, pi / 2, pi / 2; dv = u(t, x, y)) isa Float64
+    @test sol(pi / 2, pi / 2, pi / 2; dv=u(t, x, y)) isa Float64
     @test sol(pi / 2, pi / 2, :) isa Vector{Vector{Float64}}
     @test sol(pi / 2, :, :)[1] isa Matrix{Float64}
 
@@ -102,7 +101,7 @@ end
 
     @test sol[u(x, y)] == solu
 
-    @test sol(pi / 4, pi / 4, dv = u(x, y)) isa Float64
+    @test sol(pi / 4, pi / 4, dv=u(x, y)) isa Float64
     @test sol(pi / 4, :)[1] isa Vector{Float64}
 
     @test (sol[x] == sol[y])

--- a/test/components/solution_interface.jl
+++ b/test/components/solution_interface.jl
@@ -38,7 +38,7 @@ using ModelingToolkit: Differential
 
     # Solve ODE problem
     using OrdinaryDiffEq
-    sol = solve(prob, Euler(), dt=0.025, saveat=0.1)
+    sol = solve(prob, FBDF(), saveat=0.1)
 
     grid = get_discrete(pdesys, discretization)
 

--- a/test/pde_systems/MOL_1D_Interface_Nonlinear.jl
+++ b/test/pde_systems/MOL_1D_Interface_Nonlinear.jl
@@ -1,0 +1,49 @@
+using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+
+# Parameters, variables, and derivatives
+@parameters t x1 x2
+@variables c1(..)
+@variables c2(..)
+Dt = Differential(t)
+
+Dx1 = Differential(x1)
+Dxx1 = Dx1^2
+
+Dx2 = Differential(x2)
+Dxx2 = Dx2^2
+
+D1(c) = 1 + c/10
+D2(c) = 1/10 + c/10
+
+eqs = [Dt(c1(t, x1)) ~ Dx1(D1(c1(t, x1))*Dx1(c1(t, x1))),
+       Dt(c2(t, x2)) ~ Dx2(D2(c2(t, x2))*Dx2(c2(t, x2)))]
+
+bcs = [c1(0, x1) ~ -x1 * (x1 - 1) * sin(x1),
+         c2(0, x2) ~ -x2 * (x2 - 1) * sin(x2),
+         c1(t, 0) ~ 0,
+         c1(t, 0.5) ~ c2(t, 0.5),
+        -D1(c1(t, 0.5))*Dx1(c1(t, 0.5)) ~ -D2(c2(t, 0.5))*Dx2(c2(t, 0.5)),
+         c2(t, 1) ~ 0]
+
+domains = [t ∈ Interval(0.0, 1.0),
+           x1 ∈ Interval(0.0, 0.5),
+           x2 ∈ Interval(0.5, 1.0)]
+
+@named pdesys = PDESystem(eqs, bcs, domains,
+                          [t, x1, x2], [c1(t, x1), c2(t, x2)])
+
+l = 10
+
+discretization = MOLFiniteDifference([x1 => l, x2 => l], t)
+
+prob = discretize(pdesys, discretization)
+
+sol = solve(prob, Tsit5(), saveat=0.1)
+
+x1_sol = sol[x1]
+x2_sol = sol[x2]
+t_sol = sol[t]
+solc1 = sol[c1(t, x1)]
+solc2 = sol[c2(t, x2)]
+
+solc = vcat(solc1[end, :], solc2[end, 2:end])

--- a/test/pde_systems/MOL_1D_Linear_Diffusion.jl
+++ b/test/pde_systems/MOL_1D_Linear_Diffusion.jl
@@ -818,6 +818,6 @@ end
     solc1 = sol[c1(t, x1)]
     solc2 = sol[c2(t, x2)]
 
-    solc = hcat(solc1[end, :], solc2[end, 2:end])
+    solc = vcat(solc1[end, :], solc2[end, 2:end])
     @test solc ≈ zeros(length(solc)) atol = 0.001
 end

--- a/test/pde_systems/MOL_1D_Linear_Diffusion.jl
+++ b/test/pde_systems/MOL_1D_Linear_Diffusion.jl
@@ -792,8 +792,8 @@ end
     eqs = [Dt(c1(t, x1)) ~ Dxx1(c1(t, x1)),
             Dt(c2(t, x2)) ~ Dxx2(c2(t, x2))]
 
-    bcs = [c1(0, x) ~ -x * (x - 1) * sin(x),
-           c2(0, x) ~ x * (x - 1) * sin(x),
+    bcs = [c1(0, x1) ~ -x1 * (x1 - 1) * sin(x1),
+           c2(0, x2) ~ x2 * (x2 - 1) * sin(x2),
            c1(t, 0) ~ 0,
            c1(t, 0.5) ~ c2(t, 0.5),
            c2(t, 1) ~ 0]

--- a/test/pde_systems/MOL_1D_Linear_Diffusion.jl
+++ b/test/pde_systems/MOL_1D_Linear_Diffusion.jl
@@ -777,40 +777,47 @@ end
     end
 end
 
-# @testset "Test error 01: Test Higher Centered Order" begin
-#     # Method of Manufactured Solutions
-#     u_exact = (x,t) -> exp.(-t) * cos.(x)
+@testset "Test 14: linear diffusion, two variables connected at an interface, dirichlet bcs" begin
+    @parameters t x1 x2
+    @variables c1(..)
+    @variables c2(..)
+    Dt = Differential(t)
 
-#     # Parameters, variables, and derivatives
-#     @parameters t x
-#     @variables u(..)
-#     Dt = Differential(t)
-#     Dxx = Differential(x)^2
+    Dx1 = Differential(x1)
+    Dxx1 = Dx1^2
 
-#     # 1D PDE and boundary conditions
-#     eq  = Dt(u(t,x)) ~ Dxx(u(t,x))
-#     bcs = [u(0,x) ~ cos(x),
-#            u(t,0) ~ exp(-t),
-#            u(t,Float64(π)) ~ -exp(-t)]
+    Dx2 = Differential(x2)
+    Dxx2 = Dx2^2
 
-#     # Space and time domains
-#     domains = [t ∈ Interval(0.0,1.0),
-#                x ∈ Interval(0.0,Float64(π))]
+    eqs = [Dt(c1(t, x1)) ~ Dxx1(c1(t, x1)),
+            Dt(c2(t, x2)) ~ Dxx2(c2(t, x2))]
 
-#     # PDE system
-#     @named pdesys = PDESystem(eq,bcs,domains,[t,x],[u(t,x)])
+    bcs = [c1(0, x) ~ -x * (x - 1) * sin(x),
+           c2(0, x) ~ x * (x - 1) * sin(x),
+           c1(t, 0) ~ 0,
+           c1(t, 0.5) ~ c2(t, 0.5),
+           c2(t, 1) ~ 0]
 
-#     # Method of lines discretization
-#     dx = range(0.0,Float64(π),length=30)
-#     dx_ = dx[2]-dx[1]
+    domains = [t ∈ Interval(0.0, 1.0),
+               x1 ∈ Interval(0.0, 0.5),
+               x2 ∈ Interval(0.5, 1.0)]
 
-#     # Explicitly specify and invalid order of centered difference
-#     for order in 1:6
-#         discretization = MOLFiniteDifference([x=>dx_],t;approx_order=order)
-#         if order % 2 != 0
-#             @test discretize(pdesys,discretization)
-#         else
-#             discretize(pdesys,discretization)
-#         end
-#     end
-# end
+    @named pdesys = PDESystem(eqs, bcs, domains, [t, x1, x2], [c1(t, x1), c2(t, x2)])
+
+    l = 10
+
+    discretization = MOLFiniteDifference([x1 => l, x2 => l], t)
+
+    prob = discretize(pdesys, discretization)
+
+    sol = solve(prob, Tsit5(), saveat=0.1)
+
+    x1_sol = sol[x1]
+    x2_sol = sol[x2]
+    t_sol = sol[t]
+    solc1 = sol[c1(t, x1)]
+    solc2 = sol[c2(t, x2)]
+
+    solc = hcat(solc1[end, :], solc2[end, 2:end])
+    @test solc ≈ zeros(length(solc)) atol = 0.001
+end

--- a/test/pde_systems/MOLtest.jl
+++ b/test/pde_systems/MOLtest.jl
@@ -452,3 +452,54 @@ end
     end
 
 end
+
+@testset "Nonlinlap with flux interface boundary condition" begin
+    @parameters t x1 x2
+    @variables c1(..)
+    @variables c2(..)
+    Dt = Differential(t)
+
+    Dx1 = Differential(x1)
+    Dxx1 = Dx1^2
+
+    Dx2 = Differential(x2)
+    Dxx2 = Dx2^2
+
+    D1(c) = 1 + c/10
+    D2(c) = 1/10 + c/10
+
+    eqs = [Dt(c1(t, x1)) ~ Dx1(D1(c1(t, x1)) * Dx1(c1(t, x1))),
+        Dt(c2(t, x2)) ~ Dx2(D2(c2(t, x2)) * Dx2(c2(t, x2)))]
+
+    bcs = [c1(0, x1) ~ 1 + cospi(2*x1),
+        c2(0, x2) ~ 1 + cospi(2*x2),
+        Dx1(c1(t, 0)) ~ 0,
+        c1(t, 0.5) ~ c2(t, 0.5),
+        -D1(c1(t, 0.5)) * Dx1(c1(t, 0.5)) ~ -D2(c2(t, 0.5)) * Dx2(c2(t, 0.5)),
+        Dx2(c2(t, 1)) ~ 0]
+
+    domains = [t ∈ Interval(0.0, 0.15),
+        x1 ∈ Interval(0.0, 0.5),
+        x2 ∈ Interval(0.5, 1.0)]
+
+    @named pdesys = PDESystem(eqs, bcs, domains,
+        [t, x1, x2], [c1(t, x1), c2(t, x2)])
+
+    l = 40
+
+    disc = MOLFiniteDifference([x1 => l, x2 => l], t)
+
+    prob = discretize(pdesys, disc)
+
+    sol = solve(prob, FBDF(), saveat=0.01)
+
+    x1_sol = sol[x1]
+    x2_sol = sol[x2]
+    t_sol = sol[t]
+    solc1 = sol[c1(t, x1)]
+    solc2 = sol[c2(t, x2)]
+
+    solc = hcat(solc1[:, :], solc2[:, 2:end])
+
+    @test sol.retcode == :Success
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,20 +7,9 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
 # Start Test Script
 
 @time begin
-    if GROUP == "All" || GROUP == "Convection"
-        @time @safetestset "MOLFiniteDifference Interface: Linear Convection" begin
-            include("pde_systems/MOL_1D_Linear_Convection.jl")
-        end
-    end
-
     if GROUP == "All" || GROUP == "Convection_WENO"
         @time @safetestset "MOLFiniteDifference Interface: Linear Convection, WENO Scheme." begin
             include("pde_systems/MOL_1D_Linear_Convection_WENO.jl")
-        end
-    end
-    if GROUP == "All" || GROUP == "Diffusion"
-        @time @safetestset "MOLFiniteDifference Interface: 1D Linear Diffusion" begin
-            include("pde_systems/MOL_1D_Linear_Diffusion.jl")
         end
     end
 
@@ -102,6 +91,18 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
     if GROUP == "All" || GROUP == "Burgers"
         @time @safetestset "MOLFiniteDifference Interface: 2D Burger's Equation" begin
             include("pde_systems/burgers_eq.jl")
+        end
+    end
+
+    if GROUP == "All" || GROUP == "Diffusion"
+        @time @safetestset "MOLFiniteDifference Interface: 1D Linear Diffusion" begin
+            include("pde_systems/MOL_1D_Linear_Diffusion.jl")
+        end
+    end
+
+    if GROUP == "All" || GROUP == "Convection"
+        @time @safetestset "MOLFiniteDifference Interface: Linear Convection" begin
+            include("pde_systems/MOL_1D_Linear_Convection.jl")
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,6 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
 # Start Test Script
 
 @time begin
-    if GROUP == "All" || GROUP == "Diffusion"
-        @time @safetestset "MOLFiniteDifference Interface: 1D Linear Diffusion" begin
-            include("pde_systems/MOL_1D_Linear_Diffusion.jl")
-        end
-    end
     if GROUP == "All" || GROUP == "Convection"
         @time @safetestset "MOLFiniteDifference Interface: Linear Convection" begin
             include("pde_systems/MOL_1D_Linear_Convection.jl")
@@ -21,6 +16,11 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
     if GROUP == "All" || GROUP == "Convection_WENO"
         @time @safetestset "MOLFiniteDifference Interface: Linear Convection, WENO Scheme." begin
             include("pde_systems/MOL_1D_Linear_Convection_WENO.jl")
+        end
+    end
+    if GROUP == "All" || GROUP == "Diffusion"
+        @time @safetestset "MOLFiniteDifference Interface: 1D Linear Diffusion" begin
+            include("pde_systems/MOL_1D_Linear_Diffusion.jl")
         end
     end
 


### PR DESCRIPTION
Allow connecting 2 variables together in bcs, if they have the same dimensionality and a similar argument signature, differing in no or one variable.

This only works for connecting the lower of one variable to the upper of another

Supersedes Periodic conditions

fixes #32 
fixes #202 