### PR TITLE
use abstractodesolution to allow sol = solve(prob)

### DIFF
--- a/src/interface/solution/timedep.jl
+++ b/src/interface/solution/timedep.jl
@@ -1,5 +1,5 @@
 
-function SciMLBase.PDETimeSeriesSolution(sol::SciMLBase.ODESolution{T}, metadata::MOLMetadata) where {T}
+function SciMLBase.PDETimeSeriesSolution(sol::SciMLBase.AbstractODESolution{T}, metadata::MOLMetadata) where {T}
     try
         odesys = sol.prob.f.sys
 


### PR DESCRIPTION
not sure if tests will pass, but this allows me to solve without an alg