### PR TITLE
Integration over the whole domain

### DIFF
--- a/docs/src/tutorials/PIDE.md
+++ b/docs/src/tutorials/PIDE.md
@@ -51,3 +51,42 @@ solu = sol[u(t, x)]
 
 plot(sol[x], transpose(solu))
 ```
+
+To have an integral over the whole domain, be sure to wrap the integral in an auxiliary variable.
+Due to a limitation, the whole domain integral needs to have the same arguments as the integrand, but is constant in x. To use it in an equation one dimension lower, use a boundary value like integral(t, 0.0)
+
+```@example integrals2
+@parameters t, x
+@variables integrand(..) integral(..)
+Dt = Differential(t)
+Dx = Differential(x)
+xmin = 0.0
+xmax = 2.0 * pi
+
+Ix = Integral(x in DomainSets.ClosedInterval(xmin, xmax)) # integral over domain
+
+eqs = [integral(t, x) ~ Ix(integrand(t, x))
+    integrand(t, x) ~ t * cos(x)]
+
+bcs = [intergral(0, x) ~ 0.0,
+    integrand(0, x) ~ 0.0]
+
+domains = [t ∈ Interval(0.0, 1.0),
+    x ∈ Interval(xmin, xmax)]
+
+@named pde_system = PDESystem(eqs, bcs, domains, [t, x], [integrand(t, x), integral(t, x)])
+
+asf(t) = 0.0
+
+disc = MOLFiniteDifference([x => 120], t)
+
+prob = discretize(pde_system, disc)
+
+sol = solve(prob, Tsit5())
+
+xdisc = sol[x]
+tdisc = sol[t]
+
+integralsol = sol[integral(t, x)]
+exact = [asf(t_) for t_ in tdisc, x_ in xdisc]
+```

--- a/src/discretization/schemes/integral_expansion/integral_expansion.jl
+++ b/src/discretization/schemes/integral_expansion/integral_expansion.jl
@@ -1,39 +1,57 @@
-#TODO: Add support for non-uniform dx
-#TODO: Use the rectangle rule, trapezium rule and simpsons rule to approximate the integral.
+# use the trapezoid rule
 function _euler_integral(II, s, jx, u, ufunc, dx::Number) #where {T,N,Wind,DX<:Number}
     j, x = jx
+    if II[j] == 1
+        return Num(0)
+    end
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
     # dx for multiplication
+    Itap = [II - I1, II]
+    weights = [dx/2, dx/2]
 
-    Itap = [(II - I1 * i) for i = 0:(II[j]-1)] # Sum from current position till CartesianIndex 2
-    weights = [dx * (i != (II[j] - 1)) for i = 0:(II[j]-1)]
-
-    return dot(weights, ufunc(u, Itap, x))
+    return dot(weights, ufunc(u, Itap, x)) + _euler_integral(II-I1, s, jx, u, ufunc, dx)
 end
 
 # Nonuniform dx
 function _euler_integral(II, s, jx, u, ufunc, dx::AbstractVector) #where {T,N,Wind,DX<:Number}
     j, x = jx
+    if II[j] == 1
+        return Num(0)
+    end
     # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
     # dx for multiplication
+    Itap = [II - I1, II]
+    weights = fill(dx[II[j]-1]/2, 2)
 
-    Itap = [(II - I1 * i) for i = (II[j]-1):-1:0] # Sum from current position till CartesianIndex 2
-    weights = [dx[i+1] * (i != 1) for i = 0:(II[j]-1)]
-
-    return dot(weights, ufunc(u, Itap, x))
+    return dot(weights, ufunc(u, Itap, x)) + _euler_integral(II - I1, s, jx, u, ufunc, dx)
 end
 
 function euler_integral(II, s, jx, u, ufunc)
-    dx = s.dxs[jx[2]]
+    j, x = jx
+    dx = s.dxs[x]
     return _euler_integral(II, s, jx, u, ufunc, dx)
+end
+
+# uniform case of an integral across the whole domain (xmin .. xmax)
+function whole_domain_integral(II, s, jx, u, ufunc)
+    j, x = jx
+    dx = s.dxs[x]
+    dist2max = length(s.discvars[u]) - II[j]
+    I1 = unitindex(ndims(u, s), j)
+    Imax = II + dist2max * I1
+    return _euler_integral(Imax, s, jx, u, ufunc, dx)
 end
 
 @inline function generate_integration_rules(II::CartesianIndex, s::DiscreteSpace, depvars, indexmap, terms)
     ufunc(u, I, x) = s.discvars[u][I]
 
-    return reduce(vcat, [[Integral(x in DomainSets.ClosedInterval(s.vars.intervals[x][1], Num(x)))(u) => euler_integral(Idx(II, s, u, indexmap), s, (x2i(s, u, x), x), u, ufunc)
-                          for x in params(u, s)]
-                         for u in depvars])
+    eulerrules = reduce(vcat, [[Integral(x in DomainSets.ClosedInterval(s.vars.intervals[x][1], Num(x)))(u) => euler_integral(Idx(II, s, u, indexmap), s, (x2i(s, u, x), x), u, ufunc)
+                                for x in params(u, s)]
+                               for u in depvars])
+    wholedomainrules = reduce(vcat, [[Integral(x in DomainSets.ClosedInterval(s.vars.intervals[x][1], s.vars.intervals[x][2]))(u) => whole_domain_integral(Idx(II, s, u, indexmap), s, (x2i(s, u, x), x), u, ufunc)
+                                      for x in params(u, s)]
+                                     for u in depvars])
+    return vcat(eulerrules, wholedomainrules)
 end

--- a/src/discretization/schemes/integral_expansion/integral_expansion.jl
+++ b/src/discretization/schemes/integral_expansion/integral_expansion.jl
@@ -38,7 +38,7 @@ end
 function whole_domain_integral(II, s, jx, u, ufunc)
     j, x = jx
     dx = s.dxs[x]
-    dist2max = length(s.discvars[u]) - II[j]
+    dist2max = length(s, x) - II[j]
     I1 = unitindex(ndims(u, s), j)
     Imax = II + dist2max * I1
     return _euler_integral(Imax, s, jx, u, ufunc, dx)

--- a/src/discretization/schemes/integral_expansion/integral_expansion.jl
+++ b/src/discretization/schemes/integral_expansion/integral_expansion.jl
@@ -34,7 +34,7 @@ function euler_integral(II, s, jx, u, ufunc)
     return _euler_integral(II, s, jx, u, ufunc, dx)
 end
 
-# uniform case of an integral across the whole domain (xmin .. xmax)
+# An integral across the whole domain (xmin .. xmax)
 function whole_domain_integral(II, s, jx, u, ufunc)
     j, x = jx
     dx = s.dxs[x]

--- a/src/system_parsing/pde_system_transformation.jl
+++ b/src/system_parsing/pde_system_transformation.jl
@@ -145,7 +145,9 @@ function descend_to_incompatible(term, v)
             end
         elseif op isa Integral
             if any(isequal(op.domain.variables), v.x̄)
-                if op.domain.domain.left == v.intervals[op.domain.variables][1] && isequal(op.domain.domain.right, Num(op.domain.variables))
+                euler = isequal(op.domain.domain.left, v.intervals[op.domain.variables][1]) && isequal(op.domain.domain.right, Num(op.domain.variables))
+                whole = isequal(op.domain.domain.left, v.intervals[op.domain.variables][1]) && isequal(op.domain.domain.right, v.intervals[op.domain.variables][2])
+                if any([euler, whole])
                     u = arguments(term)[1]
                     out = check_deriv_arg(u, v)
                     @assert out == (nothing, false) "Integral $term must be purely of a variable, got $u. Try wrapping the integral argument with an auxiliary variable."

--- a/src/system_parsing/pde_system_transformation.jl
+++ b/src/system_parsing/pde_system_transformation.jl
@@ -288,7 +288,7 @@ function generate_aux_bc!(newbcs, newvar, term, bc::AbstractTruncatingBoundary, 
     push!(newbcs, newbc)
 end
 
-function update_boundarymap!(boundarymap, bcs, newop, v) where {K,V}
+function update_boundarymap!(boundarymap, bcs, newop, v)
     merge!(boundarymap, Dict(newop => Dict(iv => [] for iv in all_ivs(v))))
     for bc1 in bcs
         for bc2 in setdiff(bcs, [bc1])

--- a/test/pde_systems/MOL_1D_Integration.jl
+++ b/test/pde_systems/MOL_1D_Integration.jl
@@ -78,7 +78,7 @@ end
     @test cumuSumsol ≈ exact atol = 0.36
 end
 
-@test_broken begin #@testset "Test 01: Test integration over whole domain, (xmin .. xmax)" begin
+@testset "Test 01: Test integration over whole domain, (xmin .. xmax)" begin
     # test integrals
     @parameters t, x
     @variables integrand(..) cumuSum(..)
@@ -115,7 +115,7 @@ end
 
     exact = [asf(t_) for t_ in tdisc]
 
-    @test cumuSumsol ≈ exact atol = 0.36
+    @test cumuSumsol ≈ exact atol = 0.3
 end
 
 @test_broken begin #@testset "Test 02: Test integration with arbitrary limits, (a .. b)" begin

--- a/test/pde_systems/MOL_1D_Integration.jl
+++ b/test/pde_systems/MOL_1D_Integration.jl
@@ -89,10 +89,10 @@ end
 
     Ix = Integral(x in DomainSets.ClosedInterval(xmin, xmax)) # integral over domain
 
-    eqs = [cumuSum(t) ~ Ix(integrand(t, x))
+    eqs = [cumuSum(t, x) ~ Ix(integrand(t, x))
         integrand(t, x) ~ t * cos(x)]
 
-    bcs = [cumuSum(0) ~ 0.0,
+    bcs = [cumuSum(0, x) ~ 0.0,
         integrand(0, x) ~ 0.0]
 
     domains = [t ∈ Interval(0.0, 1.0),
@@ -106,14 +106,15 @@ end
 
     prob = discretize(pde_system, disc)
 
-    sol = solve(prob, Tsit5(), saveat=0.1)
+    sol = solve(prob, Tsit5())
 
     xdisc = sol[x]
     tdisc = sol[t]
 
-    cumuSumsol = sol[cumuSum(t)]
+    cumuSumsol = sol[cumuSum(t, x)]
 
-    exact = [asf(t_) for t_ in tdisc]
+
+    exact = [asf(t_) for t_ in tdisc, x_ in xdisc]
 
     @test cumuSumsol ≈ exact atol = 0.3
 end

--- a/test/pde_systems/MOL_1D_Integration.jl
+++ b/test/pde_systems/MOL_1D_Integration.jl
@@ -98,7 +98,7 @@ end
     domains = [t ∈ Interval(0.0, 1.0),
         x ∈ Interval(xmin, xmax)]
 
-    @named pde_system = PDESystem(eqs, bcs, domains, [t, x], [integrand(t, x), cumuSum(t)])
+    @named pde_system = PDESystem(eqs, bcs, domains, [t, x], [integrand(t, x), cumuSum(t, x)])
 
     asf(t) = 0.0
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,9 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
 # Start Test Script
 
 @time begin
-    if GROUP == "All" || GROUP == "Convection_WENO"
-        @time @safetestset "MOLFiniteDifference Interface: Linear Convection, WENO Scheme." begin
-            include("pde_systems/MOL_1D_Linear_Convection_WENO.jl")
+    if GROUP == "All" || GROUP == "Integrals"
+        @time @safetestset "MOLFiniteDifference Interface: Integrals" begin
+            include("pde_systems/MOL_1D_Integration.jl")
         end
     end
 
@@ -99,6 +99,12 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
         end
     end
 
+    if GROUP == "All" || GROUP == "Convection_WENO"
+        @time @safetestset "MOLFiniteDifference Interface: Linear Convection, WENO Scheme." begin
+            include("pde_systems/MOL_1D_Linear_Convection_WENO.jl")
+        end
+    end
+
     if GROUP == "All" || GROUP == "Burgers"
         @time @safetestset "MOLFiniteDifference Interface: 2D Burger's Equation" begin
             include("pde_systems/burgers_eq.jl")
@@ -114,12 +120,6 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
     if GROUP == "All" || GROUP == "Convection"
         @time @safetestset "MOLFiniteDifference Interface: Linear Convection" begin
             include("pde_systems/MOL_1D_Linear_Convection.jl")
-        end
-    end
-
-    if GROUP == "All" || GROUP == "Integrals"
-        @time @safetestset "MOLFiniteDifference Interface: Integrals" begin
-            include("pde_systems/MOL_1D_Integration.jl")
         end
     end
 


### PR DESCRIPTION
Due to a limitation, the whole domain integral needs to have the same arguments as the integrand, but is constant in `x`. To use it in an equation one dimension lower, use a boundary value like `integral(t, 0.0)`
```
    # test integrals
    @parameters t, x
    @variables integrand(..) integral(..)
    Dt = Differential(t)
    Dx = Differential(x)
    xmin = 0.0
    xmax = 2.0 * pi

    Ix = Integral(x in DomainSets.ClosedInterval(xmin, xmax)) # integral over domain

    eqs = [integral(t, x) ~ Ix(integrand(t, x))
        integrand(t, x) ~ t * cos(x)]

    bcs = [intergral(0, x) ~ 0.0,
        integrand(0, x) ~ 0.0]

    domains = [t ∈ Interval(0.0, 1.0),
        x ∈ Interval(xmin, xmax)]

    @named pde_system = PDESystem(eqs, bcs, domains, [t, x], [integrand(t, x), integral(t, x)])

    asf(t) = 0.0

    disc = MOLFiniteDifference([x => 120], t)

    prob = discretize(pde_system, disc)

    sol = solve(prob, Tsit5())

    xdisc = sol[x]
    tdisc = sol[t]

    integralsol = sol[integral(t, x)]
    exact = [asf(t_) for t_ in tdisc, x_ in xdisc]
```

fixes #94 