### PR TITLE
add Piecewise Parabolic Method discretization method

### DIFF
--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -4,8 +4,8 @@ function interface_errors(depvars, indvars, discretization)
     for x in indvars
         @assert haskey(discretization.dxs, Num(x)) || haskey(discretization.dxs, x) "Variable $x has no step size"
     end
-    if !(typeof(discretization.advection_scheme) ∈ [UpwindScheme, WENOScheme])
-        throw(ArgumentError("Only `UpwindScheme()` and `WENOScheme()` are supported advection schemes."))
+    if !(typeof(discretization.advection_scheme) ∈ [UpwindScheme, WENOScheme, PPMScheme])
+        throw(ArgumentError("Only `UpwindScheme()`, `PPMScheme()`, and `WENOScheme()` are supported advection schemes."))
     end
     if !(typeof(discretization.disc_strategy) ∈ [ScalarizedDiscretization])
         throw(ArgumentError("Only `ScalarizedDiscretization()` are supported discretization strategies."))
@@ -116,7 +116,7 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Method
         if disc_strategy isa ScalarizedDiscretization
             # Generate the equations for the interior points
             discretize_equation!(alleqs, bceqs, pde, interiormap, eqvar, bcmap,
-                depvars, s, derivweights, indexmap)
+                depvars, s, derivweights, indexmap, get(discretization.kwargs, :show_symbolic, false))
         else
             throw(ArgumentError("Only ScalarizedDiscretization is currently supported"))
         end

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -66,6 +66,7 @@ include("discretization/schemes/half_offset_centred_difference.jl")
 include("discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl")
 include("discretization/schemes/spherical_laplacian/spherical_laplacian.jl")
 include("discretization/schemes/WENO/WENO.jl")
+include("discretization/schemes/PPM/PPM.jl")
 include("discretization/schemes/integral_expansion/integral_expansion.jl")
 
 # System Discretization
@@ -79,6 +80,6 @@ include("scalar_discretization.jl")
 include("MOL_discretization.jl")
 
 export MOLFiniteDifference, discretize, symbolic_discretize, ODEFunctionExpr, generate_code, grid_align, edge_align, center_align, get_discrete
-export UpwindScheme, WENOScheme
+export UpwindScheme, WENOScheme, PPMScheme
 
 end

--- a/src/discretization/generate_finite_difference_rules.jl
+++ b/src/discretization/generate_finite_difference_rules.jl
@@ -58,6 +58,10 @@ function generate_finite_difference_rules(II::CartesianIndex, s::DiscreteSpace, 
             advection_rules = generate_WENO_rules(II, s, depvars, derivweights, bmap, indexmap, terms)
             advection_rules = vcat(advection_rules,
                                 generate_winding_rules(II, s, depvars, derivweights, bmap, indexmap, terms; skip = [1]))
+        elseif derivweights.advection_scheme isa PPMScheme
+            advection_rules = generate_PPM_rules(II, s, depvars, derivweights, bmap, indexmap, terms)
+            advection_rules = vcat(advection_rules,
+                                generate_winding_rules(II, s, depvars, derivweights, bmap, indexmap, terms; skip = [1]))
         else
             error("Unsupported advection scheme $(derivweights.advection_scheme) encountered.")
         end

--- a/src/discretization/schemes/PPM/PPM.jl
+++ b/src/discretization/schemes/PPM/PPM.jl
@@ -1,0 +1,102 @@
+"""
+Implements the piecewise parabolic method for fixed dx.
+Uses Equation 1.9 from Collela and Woodward, 1984. 
+"""
+function ppm(II::CartesianIndex, s::DiscreteSpace, ppmscheme::PPMScheme, bs, jx, u, dx::Number)
+    j, x = jx
+    I1 = unitindex(ndims(u, s), j)
+
+    udisc = s.discvars[u]
+
+    Im2 = bwrap(II - 2I1, bs, s, jx)
+    Im1 = bwrap(II - I1, bs, s, jx)
+    Ip1 = bwrap(II + I1, bs, s, jx)
+    Ip2 = bwrap(II + 2I1, bs, s, jx)
+    is = map(I -> I[j], [Im2, Im1, Ip1, Ip2])
+    for i in is
+        if i < 1
+            return nothing
+        elseif i > length(s, x)
+            return nothing
+        end
+    end
+
+    u_m2 = udisc[Im2]
+    u_m1 = udisc[Im1]
+    u_0 = udisc[II]
+    u_p1 = udisc[Ip1]
+    u_p2 = udisc[Ip2]
+
+    ap = (7/12) * (u_0 + u_p1) - (1/12) * (u_p2 - u_m1)
+    am = (7/12) * (u_m1 + u_0) - (1/12) * (u_p1 - u_m2)
+    return (ap - am) / dx
+end 
+
+function ppm(II::CartesianIndex, s::DiscreteSpace, b, jx, u, dx::AbstractVector)
+    j, x = jx
+    I1 = unitindex(ndims(u, s), j)
+
+    udisc = s.discvars[u]
+
+    Im2 = bwrap(II - 2I1, bs, s, jx)
+    Im1 = bwrap(II - I1, bs, s, jx)
+    Ip1 = bwrap(II + I1, bs, s, jx)
+    Ip2 = bwrap(II + 2I1, bs, s, jx)
+    is = map(I -> I[j], [Im2, Im1, Ip1, Ip2])
+    for i in is
+        if i < 1
+            return nothing
+        elseif i > length(s, x)
+            return nothing
+        end
+    end
+
+    u_m2 = udisc[Im2]
+    u_m1 = udisc[Im1]
+    u_0 = udisc[II]
+    u_p1 = udisc[Ip1]
+    u_p2 = udisc[Ip2]
+
+    # CW 1.7
+    d_a0 = (dx[II] / (dx[Im1] + dx[II] + dx[Ip1])) * ((2 * dx[Im1] + dx[II]) * (u_p1 - u_0) / (dx[Ip1] + dx[II]) + (dx[II] + 2 * dx[Ip1]) * (u_0 - u_m1) / (dx[Im1] + dx[II]))
+    d_am1 = (dx[Im1] / (dx[Im2] + dx[Im1] + dx[II])) * ((2 * dx[Im2] + dx[Im1]) * (u_0 - u_m1) / (dx[II] + dx[Im1]) + (dx[Im1] + 2 * dx[II]) * (u_m1 - u_m2) / (dx[Im2] + dx[Im1]))
+
+    # CW 1.8
+    ud_p1 = u_p1 - u_0
+    ud_0 = u_0 - u_m1
+    ud_m1 = u_m1 - u_m2
+    if sign(ud_p1) == sign(ud_0)
+        d_a0 = min(abs(d_a0), min(2 * abs(ud_p1), 2 * abs(ud_0))) * sign(d_a0)
+    else
+        d_a0 = 0
+    end
+    if sign(ud_0) == sign(ud_m1)
+        d_am1 = min(abs(d_am1), min(2 * abs(ud_0), 2 * abs(ud_m1))) * sign(d_am1)
+    else
+        d_am1 = 0
+    end
+
+    coeffp1 = dx[II] / (dx[II] + dx[Ip1])
+    coeffp2 = 1 / (dx[Im1] + dx[II] + dx[Ip1] + dx[Ip2])
+    coeffp3 = (2 * dx[Ip1] * dx[II]) / (dx[II] + dx[Ip1])
+    coeffp4 = (dx[Im1] + dx[II]) / (2 * dx[II] + dx[Ip1])
+    coeffp5 = (dx[Ip2] + dx[Ip1]) / (2 * dx[Ip1] + dx[II])
+    coeffp6 = dx[II] * (dx[Im1] + dx[II]) / (2 * dx[II] + dx[Ip1])
+    coeffp7 = dx[Ip1] * (dx[Ip1] + dx[Ip2]) / (dx[II] + 2 * dx[Ip1])
+
+    coeffm1 = dx[Im1] / (dx[Im1] + dx[II])
+    coeffm2 = 1 / (dx[Im2] + dx[Im1] + dx[II] + dx[Ip1])
+    coeffm3 = (2 * dx[II] * dx[Im1]) / (dx[Im1] + dx[II])
+    coeffm4 = (dx[Im2] + dx[Im1]) / (2 * dx[Im1] + dx[II])
+    coeffm5 = (dx[Ip1] + dx[II]) / (2 * dx[II] + dx[Im1])
+    coeffm6 = dx[Im1] * (dx[Im2] + dx[Im1]) / (2 * dx[Im1] + dx[II])
+    coeffm7 = dx[II] * (dx[II] + dx[Ip1]) / (dx[Im1] + 2 * dx[II])
+
+    ap = u_0 + coeffp1 * (u_p1 - u_0) + coeffp2 * (coeffp3 * (coeffp4 - coeffp5) * (u_p1 - u_0) - coeffp6 * ud_p1 + coeffp7 * ud_0)
+    am = u_m1 + coeffm1 * (u_0 - u_m1) + coeffm2 * (coeffm3 * (coeffm4 - coeffm5) * (u_0 - u_m1) - coeffm6 * ud_0 + coeffm7 * ud_m1)
+    return (ap - am) / dx[II]
+end
+
+function generate_PPM_rules(II::CartesianIndex, s::DiscreteSpace, depvars, derivweights::DifferentialDiscretizer, bcmap, indexmap, terms)
+    return reduce(safe_vcat, [[(Differential(x))(u) => ppm(Idx(II, s, u, indexmap), s, derivweights.advection_scheme, filter_interfaces(bcmap[operation(u)][x]), (x2i(s, u, x), x), u, s.dxs[x]) for x in params(u, s)] for u in depvars], init = [])
+end

--- a/src/discretization/schemes/centered_difference/centered_diff_weights.jl
+++ b/src/discretization/schemes/centered_difference/centered_diff_weights.jl
@@ -2,7 +2,7 @@
 A helper function to compute the coefficients of a derivative operator including the boundary coefficients in the centered scheme.
 """
 function CompleteCenteredDifference(derivative_order::Int,
-                                    approximation_order::Int, dx::T) where {T <: Real}
+                                    approximation_order::Int, dx::T) where T
     @assert approximation_order>1 "approximation_order must be greater than 1."
     stencil_length = derivative_order + approximation_order - 1 +
                      (derivative_order + approximation_order) % 2
@@ -54,7 +54,7 @@ end
 
 function CompleteCenteredDifference(derivative_order::Int,
                                     approximation_order::Int,
-                                    x::AbstractVector{T}) where {T <: Real}
+                                    x::AbstractVector{T}) where T
     stencil_length = derivative_order + approximation_order - 1 +
                      (derivative_order + approximation_order) % 2
     boundary_stencil_length = derivative_order + approximation_order

--- a/src/discretization/schemes/fornberg_calculate_weights.jl
+++ b/src/discretization/schemes/fornberg_calculate_weights.jl
@@ -17,7 +17,7 @@ Inputs:
                                                  derivative values respectively.                                             
 =#
 
-function calculate_weights(order::Int, x0::T, x::AbstractVector; dfdx::Bool = false) where T<:Real
+function calculate_weights(order::Int, x0::T, x::AbstractVector; dfdx::Bool = false) where T
     N = length(x)
     @assert order < N "Not enough points for the requested order."
     M = order

--- a/src/interface/MOLFiniteDifference.jl
+++ b/src/interface/MOLFiniteDifference.jl
@@ -49,5 +49,5 @@ function MOLFiniteDifference(dxs, time=nothing; approx_order = 2, advection_sche
 
     dxs = dxs isa Dict ? dxs : Dict(dxs)
 
-    return MOLFiniteDifference{typeof(grid_align), typeof(discretization_strategy)}(dxs, time, approx_order, advection_scheme, grid_align, should_transform, use_ODAE, discretization_strategy, kwargs)
+    return MOLFiniteDifference{typeof(grid_align), typeof(discretization_strategy)}(dxs, time, approx_order, advection_scheme, grid_align, should_transform, use_ODAE, discretization_strategy, Dict(kwargs))
 end

--- a/src/interface/scheme_types.jl
+++ b/src/interface/scheme_types.jl
@@ -26,4 +26,13 @@ function extent(::WENOScheme, dorder)
     return 2
 end
 
+struct PPMScheme <: AbstractScheme
+    dt
+end
+
+function extent(::PPMScheme, dorder)
+    @assert dorder == 1 "PPM requires first-order derivatives." # I think
+    return 2
+end
+
 # Note: This type and its subtypes will become important later with the stencil interfaces as we will need to dispatch on derivative order and approximation order

--- a/test/demo_parker_singular.jl
+++ b/test/demo_parker_singular.jl
@@ -1,0 +1,56 @@
+using OrdinaryDiffEq, ModelingToolkit, MethodOfLines, DomainSets
+using Symbolics: @register_symbolic
+ 
+@parameters x t
+@variables ρ(..) v(..)
+Dt = Differential(t)
+Dx = Differential(x)
+ 
+GM = 4e20
+cs = 2.87e5
+cs2 = 8.24e10
+ 
+eq = [
+        Dt(ρ(x,t)) ~ -exp(-x) * (2*ρ(x,t)*v(x,t) + v(x,t)*Dx(ρ(x,t)) + ρ(x,t)*Dx(v(x,t))),
+        Dt(v(x,t)) ~ -v(x,t)*exp(-x) * Dx(v(x,t)) - cs2/(ρ(x,t)) * exp(-x) * Dx(ρ(x,t)) - GM*exp(-2*x)
+    ]
+ 
+x_min, x_max = 20.2, 21.8
+t_min, t_max = 0.0, 30_000.0
+ 
+domains = [x ∈ Interval(x_min, x_max), t ∈ Interval(t_min, t_max)]
+ 
+ρ_init(x) = 5e-15 * exp(4.84e9 * exp(-x))
+function v_init(x)
+    if (x > 21.6)
+        return 2 * cs
+    else
+        return 0.0
+    end
+end
+ 
+@register_symbolic v_init(x)
+ 
+bcs = [
+    ρ(x,t_min) ~ ρ_init(x),
+    ρ(x_min,t) ~ ρ_init(x_min),
+    v(x,t_min) ~ v_init(x),
+    v(x_min,t) ~ v_init(x_min),
+    Dx(v(x_min,t)) ~ 0.0,
+    Dx(ρ(x_min,t)) ~ 0.0,
+    Dx(v(x_max,t)) ~ 0.0,
+    Dx(ρ(x_max,t)) ~ 0.0,
+    #Dt(v(x,t_min)) ~ 0.0,
+    #Dt(ρ(x,t_min)) ~ 0.0,
+] 
+ 
+@named pdesys = PDESystem(eq, bcs, domains, [x,t], [ρ(x,t),v(x,t)])
+ 
+N = 20
+dx = (x_max-x_min)/N
+order = 2
+discretization = MOLFiniteDifference([x=>dx], t, advection_scheme=WENOScheme())
+ 
+prob = discretize(pdesys, discretization)
+ 
+sol = solve(prob, ImplicitEuler())

--- a/test/demo_ppm_runs.jl
+++ b/test/demo_ppm_runs.jl
@@ -1,0 +1,31 @@
+using MethodOfLines, DomainSets, OrdinaryDiffEq, ModelingToolkit
+
+@parameters x t
+@variables u(..)
+Dx = Differential(x)
+Dt = Differential(t)
+x_min = 0.0
+x_max = 1.0
+t_min = 0.0
+t_max = 6.0
+
+analytic_u(t, x) = x / (t + 1)
+
+eq = Dt(u(t, x)) ~ -u(t, x) * Dx(u(t, x))
+
+bcs = [u(0, x) ~ x,
+    u(t, x_min) ~ analytic_u(t, x_min),
+    u(t, x_max) ~ analytic_u(t, x_max)]
+
+domains = [t ∈ Interval(t_min, t_max),
+    x ∈ Interval(x_min, x_max)]
+
+dx = 0.05
+
+@named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+disc = MOLFiniteDifference([x => dx], t, advection_scheme=PPMScheme(0.1))
+
+prob = discretize(pdesys, disc)
+
+sol = solve(prob, Euler(), dt=0.1)


### PR DESCRIPTION
Reference: https://www.sciencedirect.com/science/article/pii/0021999184901438?via%3Dihub

Currently `tests/demo_ppm_runs.jl` shows that it's usable as a substitute for WENO, and `tests/demo_parker_singular.jl` shows that it can create a `SingularException` that I'd like to try and chase down. 

PPM is explicitly dependent on the timestep, so only fixed-timestep methods should be used. I think the best ones are forward/implicit Euler, since that's what past astro codes that use PPM have used.

PPM is also compatible with varying dx, which I'd like to try out with the Parker wind problem (which has a logarithmic x axis that I analytically transformed to be uniform) once the fixed-dx case works.