### PR TITLE
Interpolating if one or more of the dimensions has length 1.

### DIFF
--- a/src/interface/solution/common.jl
+++ b/src/interface/solution/common.jl
@@ -19,11 +19,26 @@ function (sol::SciMLBase.PDESolution{T,N,S,D})(args...;
                 @assert i !== nothing "Independent variable $(arg_iv) in dependent variable $(dv) not found in the solution."
                 i
             end
-
+            if any(length.(sol.ivdomain) .== 1)
+                is = drop_singleton_inds(is, sol.ivdomain)
+            end
             sol.interp[dv](args[is]...)
         end
     end
+    if any(length.(sol.ivdomain) .== 1)
+        good_inds = get_good_inds(sol.ivdomain)
+        return sol.interp[dv](args[good_inds]...)
+    end
     return sol.interp[dv](args...)
+end
+
+function drop_singleton_inds(is, ivdomain)
+    bad_is = findall(a->length(a) == 1, ivdomain)
+    filter(a->!(a in bad_is), is)
+end
+
+function get_good_inds(ivdomain)
+    findall(a->length(a) > 1, ivdomain)
 end
 
 Base.@propagate_inbounds function Base.getindex(A::SciMLBase.PDESolution{T,N,S,D},


### PR DESCRIPTION
#304 

Still has a warning assertion in case all ivs have length 1. Otherwise it will build an interpolation object for the non-"singleton" ivs.

If the model is prompted to give the solution using the interpolator, it will silently ignore the missing ivs and only consider the ivs for which length is > 1.

Performance shouldn't be too big of an issue, though it would've been better to only do the singleton ivs lookup once.

It's all silent, so feel free to add warnings or let me know if you want warnings.