### PR TITLE
fixing tracing logic and adding inhomogenous, nonlinear wave eq test for staggered grid

### DIFF
--- a/src/discretization/staggered_discretize.jl
+++ b/src/discretization/staggered_discretize.jl
@@ -27,17 +27,13 @@ function symbolic_trace(prob, sys)
     u2_var = get_var_from_state(states[findfirst(x->get_var_from_state(x)!=u1_var, states)]);
     u1inds = findall(x->get_var_from_state(x)===u1_var, states);
     u2inds = findall(x->get_var_from_state(x)===u2_var, states);
-    u1 = states[u1inds]
-    u2 = states[u2inds]
-    tracevec_1 = [i in u2inds ? states[i] : Num(0.0) for i in 1:length(states)] # maybe just 0.0
-    tracevec_2 = [i in u1inds ? states[i] : Num(0.0) for i in 1:length(states)]
-    du1 = prob.f(tracevec_1, nothing, 0.0);
-    du2 = prob.f(tracevec_2, nothing, 0.0);
+    tmp = prob.f(states, nothing, 0.0)
+    du1 = [i in u1inds ? tmp[i] : Num(0.0) for i in 1:length(states)];
+    du2 = [i in u2inds ? tmp[i] : Num(0.0) for i in 1:length(states)];
     gen_du1 = eval(Symbolics.build_function(du1, states)[2]);
     gen_du2 = eval(Symbolics.build_function(du2, states)[2]);
     dynamical_f1(_du1,u,p,t) = gen_du1(_du1, u);
     dynamical_f2(_du2,u,p,t) = gen_du2(_du2, u);
     u0 = prob.u0;#[prob.u0[u1inds]; prob.u0[u2inds]];
     return SplitODEProblem(dynamical_f1, dynamical_f2, u0, prob.tspan);
-#return DynamicalODEProblem{false}(dynamical_f1, dynamical_f2, u0[1:length(u1)], u0[length(u1)+1:end], prob.tspan)
 end

--- a/test/pde_systems/wave_eq_staggered.jl
+++ b/test/pde_systems/wave_eq_staggered.jl
@@ -19,7 +19,7 @@ using OrdinaryDiffEq
     bcs = [ρ(0,x) ~ initialFunction(x),
            ϕ(0.0,x) ~ 0.0,
            Dx(ρ(t,L)) ~ 0.0,
-           ϕ(t,-L) ~ 0.0];#-a^2*Dx(ρ(t,L))];
+           ϕ(t,-L) ~ 0.0];
 
     domains = [t in Interval(0.0, tmax),
                x in Interval(-L, L)];
@@ -105,4 +105,42 @@ end
     test_ind = round(Int, ((2*L-dx)/a)/(dt))
     @test maximum(sol[1:128,1] .- sol[1:128,test_ind]) < max(dx^2, dt)
     @test maximum(sol[1:128,1] .- sol[1:128,2*test_ind]) < 10*max(dx^2, dt)
+end
+
+@testset "1D inhomogenous nonlinear wave equation, staggered grid, Mixed BC" begin
+    @parameters x
+    @variables t, ρ(..), ϕ(..)
+    Dt = Differential(t);
+    Dx = Differential(x);
+
+    β = 0.11/(2*0.01);
+    a = 0.5;
+    L = 1.0;
+    dx = 1/2^7;
+    tspan = (0.0, 6.0)
+
+    function RHS(ρ, ϕ)
+        return -β*(ϕ^2)*sign(ϕ)/ρ
+    end
+
+    eqs = [Dt(ρ(t,x)) + Dx(ϕ(t,x)) ~ 0,
+           Dt(ϕ(t,x)) + a^2*Dx(ρ(t,x)) ~ RHS(ρ(t, x), ϕ(t,x))]
+    bcs = [ρ(0,x) ~ 50.0*exp(-((x-0.5)*20)^2) + 50.0,
+           ϕ(0,x) ~ 0.0,
+           Dx(ρ(t,L)) ~ 0.0,
+           ϕ(t,0.0) ~ 0.0]
+    domains = [t in Interval(tspan[1], tspan[end]),
+               x in Interval(0.0, L)]
+
+    @named pdesys = PDESystem(eqs, bcs, domains, [t,x], [ρ(t,x), ϕ(t,x)])
+    discretization = MOLFiniteDifference([x=>dx], t, grid_align=MethodOfLines.StaggeredGrid(), edge_aligned_var=ϕ(t,x));
+    prob = discretize(pdesys, discretization);
+    @time sol = solve(prob, SplitEuler(), dt=(dx/a)^2, adaptive=false)
+    @test sol.retcode == ReturnCode.Success
+    # p = plot()
+    # for i in 1:tspan[end]*((a/dx)^2)/10:length(sol)
+    #     ind = floor(Int, i)
+    #     plot!(p, sol.u[ind], label="t = $(@sprintf("%.2f", sol.t[ind]))")
+    # end
+    # p
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
Fixes #352. Attempted to make the code a bit more robust to possibility of shuffling variables.

Test solves the inhomogenous gas flow equations:
\rho_t + \phi_x = 0
\phi_t + a^2 \rho_x = -\beta |\phi|\phi/\rho
(Instabilities are created at long times as shown in figure, but I think this should be related to #351 and so I will not attempt to solve here.
![inhomogenous_wave_eq](https://github.com/SciML/MethodOfLines.jl/assets/26753526/24c9c936-861c-405a-b636-852d07c1fd31)

