### PR TITLE
Update docs boundary_conditions.md  `@register_symbolic` instead of `@register`

### DIFF
--- a/docs/src/boundary_conditions.md
+++ b/docs/src/boundary_conditions.md
@@ -71,7 +71,7 @@ function g(x, y)
     end
 end
 
-@register g(x, y)
+@register_symbolic g(x, y)
 
 u(t, x, y_min) ~ f(t, x, y_min) + alpha / g(x, y_min)
 ```


### PR DESCRIPTION
`@register_symbolic` seems to be the right macro now?
