### PR TITLE
pass the order variable to MOLFiniteDifference

### DIFF
--- a/docs/src/tutorials/PIDE.md
+++ b/docs/src/tutorials/PIDE.md
@@ -49,7 +49,7 @@ domains = [t ∈ Interval(0.0, 2.0), x ∈ Interval(xmin, xmax)]
 @named pde_system = PDESystem(eq, bcs, domains, [t, x], [u(t, x), cumuSum(t, x)])
 
 order = 2
-discretization = MOLFiniteDifference([x => 30], t)
+discretization = MOLFiniteDifference([x => 30], t, approx_order = order)
 
 prob = MethodOfLines.discretize(pde_system, discretization)
 sol = solve(prob, QNDF(), saveat = 0.1);

--- a/docs/src/tutorials/heat.md
+++ b/docs/src/tutorials/heat.md
@@ -31,7 +31,7 @@ domains = [t ∈ Interval(0.0, 1.0),
 # Method of lines discretization
 dx = 0.1
 order = 2
-discretization = MOLFiniteDifference([x => dx], t)
+discretization = MOLFiniteDifference([x => dx], t, approx_order = order)
 
 # Convert the PDE problem into an ODE problem
 prob = discretize(pdesys, discretization)
@@ -87,7 +87,7 @@ domains = [t ∈ Interval(0.0, 1.0),
 # Need a small dx here for accuracy
 dx = 0.01
 order = 2
-discretization = MOLFiniteDifference([x => dx], t)
+discretization = MOLFiniteDifference([x => dx], t, approx_order = order)
 
 # Convert the PDE problem into an ODE problem
 prob = discretize(pdesys, discretization)
@@ -144,7 +144,7 @@ domains = [t ∈ Interval(0.0, 1.0),
 # Need a small dx here for accuracy
 dx = 0.05
 order = 2
-discretization = MOLFiniteDifference([x => dx], t)
+discretization = MOLFiniteDifference([x => dx], t, approx_order = order)
 
 # Convert the PDE problem into an ODE problem
 prob = discretize(pdesys, discretization)

--- a/docs/src/tutorials/sispde.md
+++ b/docs/src/tutorials/sispde.md
@@ -75,7 +75,7 @@ domains = [t ∈ Interval(0.0, 10.0),
 # Need a small dx here for accuracy
 dx = 0.01
 order = 2
-discretization = MOLFiniteDifference([x => dx], t)
+discretization = MOLFiniteDifference([x => dx], t, approx_order = order)
 
 # Convert the PDE problem into an ODE problem
 prob = discretize(pdesys, discretization);


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I noticed a few of the tutorials define an `order` variable but then never uses it which is mildly confusing to read. In this pr is pass this variable to the `approx_order` argument of `MOLFiniteDifference`.