### PR TITLE
Fix broken documentation links for grid alignment types

### DIFF
--- a/src/interface/MOLFiniteDifference.jl
+++ b/src/interface/MOLFiniteDifference.jl
@@ -17,7 +17,7 @@ A discretization algorithm.
 
 - `approx_order`: The order of the derivative approximation.
 - `advection_scheme`: The scheme to be used to discretize advection terms, i.e. first order spatial derivatives and associated coefficients. Defaults to `UpwindScheme()`. WENOScheme() is also available, and is more stable and accurate at the cost of complexity.
-- `grid_align`: The grid alignment types. See [`CenterAlignedGrid()`](@ref) and [`EdgeAlignedGrid()`](@ref).
+- `grid_align`: The grid alignment types. See [`CenterAlignedGrid`](@ref) and [`EdgeAlignedGrid`](@ref).
 - `use_ODAE`: If `true`, the discretization will use the `ODAEproblem` constructor.
     Defaults to `false`.
 - `kwargs`: Any other keyword arguments you want to pass to the `ODEProblem`.


### PR DESCRIPTION
## Summary
- Fixed broken documentation links for `CenterAlignedGrid` and `EdgeAlignedGrid` in MOLFiniteDifference docstring
- Removed parentheses from link text that were causing Documenter.jl to generate incorrect URLs

## Problem
As reported in #463, the documentation for the `grid_align` keyword argument in `MOLFiniteDifference` contained broken links to `CenterAlignedGrid` and `EdgeAlignedGrid`. The links were formatted as `[\`CenterAlignedGrid()\`](@ref)` which caused Documenter.jl to generate URLs that resulted in 403 Forbidden errors.

## Solution
Removed the parentheses from the link text, changing:
- `[\`CenterAlignedGrid()\`](@ref)` → `[\`CenterAlignedGrid\`](@ref)`  
- `[\`EdgeAlignedGrid()\`](@ref)` → `[\`EdgeAlignedGrid\`](@ref)`

This follows the correct Documenter.jl syntax for referencing types.

## Test plan
- [x] Built documentation locally using `julia --project=docs docs/make.jl`
- [x] Verified no broken link errors were reported
- [x] Documentation builds successfully without warnings related to these links

Fixes #463

🤖 Generated with [Claude Code](https://claude.ai/code)