### PR TITLE
Fix staggered grid discretization parameter passing

### DIFF
--- a/src/discretization/staggered_discretize.jl
+++ b/src/discretization/staggered_discretize.jl
@@ -30,8 +30,8 @@ function symbolic_trace(prob, sys)
     u2 = unknowns[u2inds]
     tracevec_1 = [i in u2inds ? unknowns[i] : Num(0.0) for i in 1:length(unknowns)] # maybe just 0.0
     tracevec_2 = [i in u1inds ? unknowns[i] : Num(0.0) for i in 1:length(unknowns)]
-    du1 = prob.f(tracevec_1, nothing, 0.0);
-    du2 = prob.f(tracevec_2, nothing, 0.0);
+    du1 = prob.f(tracevec_1, prob.p, 0.0);
+    du2 = prob.f(tracevec_2, prob.p, 0.0);
     gen_du1 = eval(Symbolics.build_function(du1, unknowns)[2]);
     gen_du2 = eval(Symbolics.build_function(du2, unknowns)[2]);
     dynamical_f1(_du1, u, p, t) = gen_du1(_du1, u);


### PR DESCRIPTION
## Summary
Fixes MethodError in staggered_discretize.jl by passing `prob.p` instead of `nothing` to `prob.f` calls.

This resolves the error `MethodError: no method matching view(::Nothing, ::UnitRange{Int64})` that occurred when using staggered grids with periodic boundary conditions.

## Problem
The `symbolic_trace` function in `src/discretization/staggered_discretize.jl` was calling `prob.f` with `nothing` as the parameters argument, but the generated `ODEFunction` expected actual parameters to perform view operations on parameter arrays.

## Solution
Changed lines 33-34 to pass `prob.p` instead of `nothing`:
```julia
du1 = prob.f(tracevec_1, prob.p, 0.0);
du2 = prob.f(tracevec_2, prob.p, 0.0);
```

## Test plan
- [x] Tested with the example from the discourse post
- [x] Verified that discretization completes successfully
- [x] Verified that the solve runs without errors

Fixes: https://discourse.julialang.org/t/methodoflines-staggered-grids-methoderror-by-function-discretize/133312

🤖 Generated with [Claude Code](https://claude.com/claude-code)