### PR TITLE
Fix potential runtime errors found by JET static analysis

### DIFF
--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -95,6 +95,7 @@ function SciMLBase.ODEFunction(
             @assert true "Codegen for NonlinearSystems is not yet implemented."
         else
             simpsys = mtkcompile(sys)
+            f_analytic = nothing
             if analytic !== nothing
                 analytic = analytic isa Dict ? analytic : Dict(analytic)
                 s = getmetadata(sys, ModelingToolkit.ProblemTypeCtx, nothing).discretespace

--- a/src/discretization/generate_bc_eqs.jl
+++ b/src/discretization/generate_bc_eqs.jl
@@ -117,12 +117,12 @@ function boundary_value_maps(II, s::DiscreteSpace{N, M, G}, boundary, derivweigh
         is = [is[1:(j - 1)]..., 1, is[j:end]...]
         II = CartesianIndex(is...)
 
-        depvarderivbcmaps = [(Differential(x__)^d)(u__) => half_offset_centered_difference(
+        otherderivmaps = [(Differential(x__)^d)(u__) => half_offset_centered_difference(
                                  derivweights.halfoffsetmap[1][Differential(x__) ^ d],
                                  II, s, [], (j, x__), otheru, ufunc)
                              for d in derivweights.orders[x_]]
 
-        depvarbcmaps = [u__ => half_offset_centered_difference(
+        otherbcmaps = [u__ => half_offset_centered_difference(
             derivweights.interpmap[x__], II, s, [], (j, x__), otheru, ufunc)]
 
         depvarderivbcmaps = vcat(depvarderivbcmaps, otherderivmaps)

--- a/src/discretization/staggered_discretize.jl
+++ b/src/discretization/staggered_discretize.jl
@@ -32,8 +32,10 @@ function symbolic_trace(prob, sys)
     tracevec_2 = [i in u1inds ? unknowns[i] : Num(0.0) for i in 1:length(unknowns)]
     du1 = prob.f(tracevec_1, prob.p, 0.0);
     du2 = prob.f(tracevec_2, prob.p, 0.0);
-    gen_du1 = eval(Symbolics.build_function(du1, unknowns)[2]);
-    gen_du2 = eval(Symbolics.build_function(du2, unknowns)[2]);
+    bf_du1 = Symbolics.build_function(du1, unknowns)
+    bf_du2 = Symbolics.build_function(du2, unknowns)
+    gen_du1 = eval(bf_du1 isa Tuple ? bf_du1[2] : bf_du1)
+    gen_du2 = eval(bf_du2 isa Tuple ? bf_du2[2] : bf_du2)
     dynamical_f1(_du1, u, p, t) = gen_du1(_du1, u);
     dynamical_f2(_du2, u, p, t) = gen_du2(_du2, u);
     u0 = prob.u0;#[prob.u0[u1inds]; prob.u0[u2inds]];


### PR DESCRIPTION
## Summary

This PR fixes three bugs discovered using JET.jl static analysis:

- **MOL_discretization.jl**: Initialize `f_analytic` to `nothing` before conditional assignment to avoid potential `UndefVarError` when `analytic=nothing`
- **generate_bc_eqs.jl**: Fix undefined `otherderivmaps`/`otherbcmaps` variables in `EdgeAlignedGrid` version of `boundary_value_maps` (copy-paste bug where variable names didn't match)
- **staggered_discretize.jl**: Handle `Symbolics.build_function` return type properly - it can return either `Expr` or `Tuple{Expr, Expr}`

## JET Analysis Results

JET errors reduced from 13 to 8. The remaining 8 errors are false positives caused by JET being unable to statically verify that `VariableMap` (from PDEBase) has the expected fields when accessed through a field typed as `Any` in `DiscreteSpace`.

## Test plan

- [x] Basic 1D diffusion discretization test passes
- [x] `ODEFunction(pdesys, discretization)` with `analytic=nothing` works correctly

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)