### PR TITLE
Fix WENOScheme to accept epsilon as keyword argument

### DIFF
--- a/src/discretization/schemes/WENO/WENO.jl
+++ b/src/discretization/schemes/WENO/WENO.jl
@@ -61,7 +61,7 @@ end
 ## Keyword Arguments
 - `epsilon`: A quantity used to prevent vanishing denominators in the scheme, defaults to `1e-6`. More sensitive problems will benefit from a smaller value. It is defined as a functional scheme.
 """
-function WENOScheme(epsilon = 1e-6)
+function WENOScheme(; epsilon = 1e-6)
     boundary_f = [nothing, nothing]
     return FunctionalScheme{5, 0}(
         weno_f, boundary_f, boundary_f, false, [epsilon], name = "WENO")


### PR DESCRIPTION
## Summary
- Fix WENOScheme function to accept `epsilon` as a keyword argument, matching the documentation and docstring

The docstring explicitly said "## Keyword Arguments" and documented `epsilon` as a keyword argument, but the function signature was `WENOScheme(epsilon = 1e-6)` (positional) instead of `WENOScheme(; epsilon = 1e-6)` (keyword).

This caused users to get `MethodError: no method matching WENOScheme(; epsilon::Float64)` when following the documentation.

Fixes #472

## Test plan
- [x] Verified `WENOScheme(epsilon=1e-6)` now works (was failing before)
- [x] Verified `WENOScheme()` still works with default value
- [x] Verified existing WENO tests pass with the fix

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)