### PR TITLE
Improve precompilation: add 1D Dirichlet and Neumann diffusion workloads

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,5 +1,60 @@
 @setup_workload begin
     @compile_workload begin
+        # Workload 1: Simple 1D diffusion with Dirichlet BCs (most common use case)
+        # This covers centered difference discretization
+        begin
+            @parameters t x
+            @variables u(..)
+            Dt = Differential(t)
+            Dxx = Differential(x)^2
+
+            eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+
+            bcs = [
+                u(0, x) ~ sin(pi * x),
+                u(t, 0.0) ~ 0.0,
+                u(t, 1.0) ~ 0.0,
+            ]
+
+            domains = [
+                t ∈ Interval(0.0, 1.0),
+                x ∈ Interval(0.0, 1.0),
+            ]
+
+            @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+            discretization = MOLFiniteDifference([x => 10], t)
+            prob = discretize(pdesys, discretization)
+        end
+
+        # Workload 2: 1D diffusion with Neumann BCs
+        begin
+            @parameters t x
+            @variables u(..)
+            Dt = Differential(t)
+            Dx = Differential(x)
+            Dxx = Differential(x)^2
+
+            eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+
+            bcs = [
+                u(0, x) ~ cos(x),
+                Dx(u(t, 0.0)) ~ 0.0,
+                Dx(u(t, 1.0)) ~ 0.0,
+            ]
+
+            domains = [
+                t ∈ Interval(0.0, 1.0),
+                x ∈ Interval(0.0, 1.0),
+            ]
+
+            @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+            discretization = MOLFiniteDifference([x => 10], t)
+            prob = discretize(pdesys, discretization)
+        end
+
+        # Workload 3: 2D Brusselator with periodic BCs (complex 2D system)
         begin
             @parameters x y t
             @variables u(..) v(..)
@@ -62,6 +117,8 @@
             # Convert the PDE problem into an ODE problem
             prob = discretize(pdesys, discretization)
         end
+
+        # Workload 4: 1D advection with WENO scheme
         begin
             @parameters x t
             @variables u(..)


### PR DESCRIPTION
## Summary

This PR improves precompilation by adding workloads for the most common use cases:

- **1D diffusion with Dirichlet BCs** - covers centered difference discretization (most common case)
- **1D diffusion with Neumann BCs** - covers derivative boundary conditions

## Performance Results

| Test Case | Before | After | Speedup |
|-----------|--------|-------|---------|
| 1D diffusion (Dirichlet) | 20.68s (98% compilation) | 1.24s (84% compilation) | **16.7x faster** |
| 1D diffusion (Neumann) | ~20s | 0.11s (0.4% compilation) | **~180x faster** |
| 1D advection (WENO) | 2.12s | 2.12s | unchanged (already precompiled) |

## Trade-off

- Precompilation time: 167s → 188s (+21s)
- This is acceptable given the significant TTFX improvements for users

## Invalidations Analysis

Checked invalidations using SnoopCompile - 364 invalidation trees were found, but they are from upstream dependencies (ChainRulesCore, MutableArithmetics, JuliaSyntax, RecursiveArrayTools, StaticArrays, etc.) not from MethodOfLines itself. These are not actionable in this package.

## Test plan

- [x] Package precompiles successfully
- [x] TTFX measurements show significant improvement
- [ ] CI tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)