### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -84,7 +84,7 @@ function ODEFunctionExpr(
         end
     catch e
         println("The system of equations is:")
-        println(sys.eqs)
+        println(get_eqs(sys))
         println()
         println("Discretization failed, please post an issue on https://github.com/SciML/MethodOfLines.jl with the failing code and system at low point count.")
         println()
@@ -116,7 +116,7 @@ function SciMLBase.ODEFunction(
         end
     catch e
         println("The system of equations is:")
-        println(sys.eqs)
+        println(get_eqs(sys))
         println()
         println("Discretization failed, please post an issue on https://github.com/SciML/MethodOfLines.jl with the failing code and system at low point count.")
         println()

--- a/src/discretization/staggered_discretize.jl
+++ b/src/discretization/staggered_discretize.jl
@@ -9,7 +9,7 @@ function SciMLBase.discretize(
         if tspan === nothing
             add_metadata!(getmetadata(sys, ModelingToolkit.ProblemTypeCtx, nothing), sys)
             return prob = NonlinearProblem(
-                simpsys, ones(length(simpsys.unknowns));
+                simpsys, ones(length(get_unknowns(simpsys)));
                 discretization.kwargs..., kwargs...
             )
         else

--- a/test/pde_systems/MOL_NonlinearProblem.jl
+++ b/test/pde_systems/MOL_NonlinearProblem.jl
@@ -15,9 +15,9 @@ using DomainSets
         0 ~ b + d - 2 * c,
         0 ~ d - 1,
     ]
-    @named ns = NonlinearSystem(eqs, [a, b, c, d], [])
+    @named ns = System(eqs, [a, b, c, d], [])
     sns = mtkcompile(ns)
-    prob = NonlinearProblem(sns, zeros(length(get_unknowns(sns))), [])
+    prob = NonlinearProblem(sns, Dict(get_unknowns(sns) .=> 0.0))
 
     sol = NonlinearSolve.solve(prob, NewtonRaphson())
 


### PR DESCRIPTION
## Summary

- Replace deprecated `NonlinearSystem()` with `System()` in test (ModelingToolkit v10 deprecation)
- Replace deprecated 3-arg `NonlinearProblem(sys, u0, p)` with `NonlinearProblem(sys, Dict(...))` in test
- Replace `simpsys.unknowns` property access with `get_unknowns(simpsys)` in `staggered_discretize.jl`
- Replace `sys.eqs` property access with `get_eqs(sys)` in error handlers in `MOL_discretization.jl`

### Details

These changes address deprecation warnings from ModelingToolkit v10.x:

1. **`NonlinearSystem` → `System`** (`test/pde_systems/MOL_NonlinearProblem.jl`): `NonlinearSystem` is deprecated in MTK v10 in favor of the unified `System` constructor.

2. **`NonlinearProblem(sys, u0, p)` → `NonlinearProblem(sys, Dict(...))`** (`test/pde_systems/MOL_NonlinearProblem.jl`): The separate `u0, p` arguments form is deprecated. The new API uses a merged `Dict`.

3. **`simpsys.unknowns` → `get_unknowns(simpsys)`** (`src/discretization/staggered_discretize.jl`): Direct property access on `System` objects is deprecated. The accessor function `get_unknowns()` should be used instead.

4. **`sys.eqs` → `get_eqs(sys)`** (`src/MOL_discretization.jl`): Same as above - property access on `System` objects in error handlers should use accessor functions.

### Note on upstream deprecations

The main MethodOfLines source code and PDEBase are already using the modern API (`mtkcompile`, `System()`, `get_eqs()`, etc.). The remaining deprecation warnings that may appear with `JULIA_DEPWARN=error` are from upstream dependencies (ModelingToolkit, PDEBase) during their internal operations, not from MethodOfLines code.

## Test plan

- [x] Verified package loads with `--depwarn=error`
- [x] Ran Stationary test group (8/8 passed) - exercises the `NonlinearSystem`/`NonlinearProblem` fixes
- [x] Ran Components test group (all passed) - exercises core functionality
- [x] Ran basic diffusion discretization test with `--depwarn=error`
- [x] Checked Runic formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)