### PR TITLE
Use linkcheck_ignore instead of blanket warnonly for flaky link

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,11 @@ makedocs(
     authors = "Chris Rackauckas, Alex Jones et al.",
     clean = true, doctest = false, linkcheck = true,
     modules = [MethodOfLines],
-    warnonly = [:docs_block, :missing_docs, :cross_references, :linkcheck],
+    warnonly = [:docs_block, :missing_docs, :cross_references],
+    linkcheck_ignore = [
+        # StackExchange returns 403 for automated requests
+        "https://math.stackexchange.com/questions/4333513/nonuniform-finite-difference-grid-for-a-pde-where-the-x-points-depends-on-y-coor",
+    ],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/MethodOfLines/stable/"


### PR DESCRIPTION
## Summary
- Replace the blanket `:linkcheck` in `warnonly` with a targeted `linkcheck_ignore` for the specific StackExchange URL that returns 403 for automated requests
- This keeps linkcheck enforcement for all other links, only skipping the known flaky one

## Test plan
- [ ] CI docs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)