### PR TITLE
Fix BoundsError in upwind_difference for nonuniform grids (Fixes #340)

### DIFF
--- a/src/discretization/schemes/upwind_difference/upwind_difference.jl
+++ b/src/discretization/schemes/upwind_difference/upwind_difference.jl
@@ -33,11 +33,14 @@ end
     ) where {T, N, Wind, DX <: AbstractVector}
     j, x = jx
     @assert length(bs) == 0 "Interface boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
+    
     I1 = unitindex(ndims(u, s), j)
-    if !ispositive
-        @assert D.offside == 0
+    haslower, hasupper = haslowerupper(bs, x)
+    
+    actual_offside = D.stencil_length - 1
 
-        if (II[j] > (length(s, x) - D.boundary_point_count))
+    if !ispositive
+        if (II[j] > (length(s, x) - actual_offside)) & !hasupper
             weights = D.high_boundary_coefs[length(s, x) - II[j] + 1]
             offset = length(s, x) - II[j]
             Itap = [II + (i + offset) * I1 for i in (-D.boundary_stencil_length + 1):0]
@@ -46,12 +49,12 @@ end
             Itap = [II + i * I1 for i in 0:(D.stencil_length - 1)]
         end
     else
-        if (II[j] <= D.offside)
+        if (II[j] <= actual_offside) & !haslower
             weights = D.low_boundary_coefs[II[j]]
             offset = 1 - II[j]
             Itap = [II + (i + offset) * I1 for i in 0:(D.boundary_stencil_length - 1)]
         else
-            weights = D.stencil_coefs[II[j] - D.offside]
+            weights = D.stencil_coefs[II[j] - actual_offside]
             Itap = [II + i * I1 for i in (-D.stencil_length + 1):0]
         end
     end

--- a/src/discretization/schemes/upwind_difference/upwind_difference.jl
+++ b/src/discretization/schemes/upwind_difference/upwind_difference.jl
@@ -33,10 +33,10 @@ end
     ) where {T, N, Wind, DX <: AbstractVector}
     j, x = jx
     @assert length(bs) == 0 "Interface boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
-    
+
     I1 = unitindex(ndims(u, s), j)
     haslower, hasupper = haslowerupper(bs, x)
-    
+
     actual_offside = D.stencil_length - 1
 
     if !ispositive


### PR DESCRIPTION
This PR resolves Issue #340 where providing a nonuniform grid (as an `AbstractVector`) to the `UpwindScheme` resulted in a `BoundsError`.

**Cause of the Bug:**
In `_upwind_difference` for `DX <: AbstractVector`, the `D.offside` value defaults to `0`. This caused the boundary check `(II[j] <= D.offside)` to fail at the lower boundary (`II[j] == 1`). Consequently, the algorithm incorrectly executed the interior stencil logic, attempting to access index `0` and throwing a `BoundsError`.

**Solution:**
Replaced the reliance on `D.offside` with a calculated `actual_offside = D.stencil_length - 1`. The boundary checks now correctly identify when the stencil approaches the domain edges, appropriately applying the boundary coefficients (`low_boundary_coefs` and `high_boundary_coefs`) without out-of-bounds indexing.
