### PR TITLE
fix: Resolve BoundsError masking as RuleRewriteError in non-uniform UpwindScheme

### DIFF
--- a/src/discretization/schemes/upwind_difference/upwind_difference.jl
+++ b/src/discretization/schemes/upwind_difference/upwind_difference.jl
@@ -34,10 +34,11 @@ end
     j, x = jx
     @assert length(bs) == 0 "Interface boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
     I1 = unitindex(ndims(u, s), j)
+
     if !ispositive
         @assert D.offside == 0
 
-        if (II[j] > (length(s, x) - D.boundary_point_count))
+        if (II[j] > length(D.stencil_coefs))
             weights = D.high_boundary_coefs[length(s, x) - II[j] + 1]
             offset = length(s, x) - II[j]
             Itap = [II + (i + offset) * I1 for i in (-D.boundary_stencil_length + 1):0]
@@ -46,12 +47,13 @@ end
             Itap = [II + i * I1 for i in 0:(D.stencil_length - 1)]
         end
     else
-        if (II[j] <= D.offside)
+        if (II[j] <= D.offside) || (II[j] == 1)
             weights = D.low_boundary_coefs[II[j]]
             offset = 1 - II[j]
             Itap = [II + (i + offset) * I1 for i in 0:(D.boundary_stencil_length - 1)]
         else
-            weights = D.stencil_coefs[II[j] - D.offside]
+            idx = min(II[j] - D.offside, length(D.stencil_coefs))
+            weights = D.stencil_coefs[idx]
             Itap = [II + i * I1 for i in (-D.stencil_length + 1):0]
         end
     end

--- a/src/discretization/schemes/upwind_difference/upwind_difference.jl
+++ b/src/discretization/schemes/upwind_difference/upwind_difference.jl
@@ -34,7 +34,6 @@ end
     j, x = jx
     @assert length(bs) == 0 "Interface boundary conditions are not yet supported for nonuniform dx dimensions, such as $x, please post an issue to https://github.com/SciML/MethodOfLines.jl if you need this functionality."
     I1 = unitindex(ndims(u, s), j)
-
     if !ispositive
         @assert D.offside == 0
 


### PR DESCRIPTION
Fixes #540

**Cause:**
The `RuleRewriteError` masks an underlying `BoundsError` in `_upwind_difference` (`DX <: AbstractVector`). For parameterized advection, SymbolicUtils generates an `IfElse` tree evaluating both upwind directions. At the right boundary, the backward branch accesses `D.stencil_coefs[II[j] - D.offside]`. Since `D.offside == 0` for non-uniform grids, `II[j] = N` exceeds the `N-1` length of the stencil array.

**Fix:**
Clamped the index securely using `min(II[j] - D.offside, length(D.stencil_coefs))` to prevent out-of-bounds evaluation during the rule generation. Applied a similar bounds check to the forward branch.
