### PR TITLE
Bump DiffEqBase / OrdinaryDiffEq / SciMLBase compat to include v7/v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "0.11.11"
+version = "0.12.0"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]
@@ -24,18 +24,18 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 Combinatorics = "1"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 DomainSets = "0.7"
 IfElse = "0.1"
 Interpolations = "0.14, 0.15, 0.16"
 Latexify = "0.15, 0.16"
 ModelingToolkit = "11"
-OrdinaryDiffEq = "6"
+OrdinaryDiffEq = "6, 7"
 PDEBase = "0.1.20"
 PrecompileTools = "1"
 RuntimeGeneratedFunctions = "0.5.12"
 SafeTestsets = "0.0.1, 0.1"
-SciMLBase = "2"
+SciMLBase = "2, 3"
 StaticArrays = "1"
 SymbolicIndexingInterface = "0.3.40"
 SymbolicUtils = "4"


### PR DESCRIPTION
## Summary

Widen compat so MethodOfLines resolves alongside the v7 OrdinaryDiffEq stack:

- `DiffEqBase: "6"` → `"6, 7"`
- `OrdinaryDiffEq: "6"` → `"6, 7"`
- `SciMLBase: "2"` → `"2, 3"`

Version bump 0.11.11 → 0.12.0. `ModelingToolkit = "11"` already covers the 11.22 in SciML/ModelingToolkit.jl#4467.

## Why this is source-level safe

Grepped `src/` clean for every symbol removed in the v7 NEWS / SciMLBase v3 breaking notes.

## Scope

Part of the v7-compat-widening set alongside DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71, ParameterizedFunctions#151, SciMLSensitivity#1431, Sundials#526, ODEInterfaceDiffEq#95, DiffEqFinancial#68, DiffEqPhysics#107.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>