### PR TITLE
Fix master CI: Schroedinger DAE init with BrownFullBasicInit

### DIFF
--- a/test/pde_systems/schroedinger.jl
+++ b/test/pde_systems/schroedinger.jl
@@ -1,4 +1,6 @@
 using MethodOfLines, OrdinaryDiffEq, DomainSets, ModelingToolkit, Test
+using SciMLBase
+using DiffEqBase: BrownFullBasicInit
 
 @testset "Schroedinger" begin
     @parameters t, x
@@ -30,7 +32,7 @@ using MethodOfLines, OrdinaryDiffEq, DomainSets, ModelingToolkit, Test
 
     prob = discretize(sys, disc)
 
-    sol = solve(prob, FBDF(), saveat = 0.01)
+    sol = solve(prob, FBDF(), saveat = 0.01, initializealg = BrownFullBasicInit())
 
     discx = sol[x]
     disct = sol[t]
@@ -89,7 +91,7 @@ end
 
     prob = discretize(sys, disc)
 
-    sol = solve(prob, FBDF(), saveat = 0.01)
+    sol = solve(prob, FBDF(), saveat = 0.01, initializealg = BrownFullBasicInit())
 
     @test SciMLBase.successful_retcode(sol)
 end


### PR DESCRIPTION
## Summary

Master `Tests (pre, Complex)` is failing because the second Schroedinger testset (`Schroedinger with complex bcs`, ϵ=1.0e-2) errors with:

```
DAE initialization failed: your u0 did not satisfy the initialization
requirements, normresid = 0.194 > abstol = 1.0e-6.
```

The Schroedinger PDE tests build ODE problems with a singular mass matrix (algebraic constraints from Dirichlet BCs after the Re/Im split). Recent MTK / SciMLBase / OrdinaryDiffEq versions tightened the default DAE initialization to `CheckInit`, which only verifies `u0` and refuses to perturb the algebraic states. Discretization noise then makes the IC fail the strict residual tolerance.

This PR passes `initializealg = BrownFullBasicInit()` on both Schroedinger testsets so the algebraic states are projected onto the constraint manifold before stepping. This is the standard recommendation in the same error message and matches the IC-consistency the tests already expect.

Reproduced last red run [24992268179](https://github.com/SciML/MethodOfLines.jl/actions/runs/24992268179) (Tests (pre, Complex)) — locally with newer-resolved deps (MTK 11.25 / SciMLBase 3.9.1) the failure also reproduces on Julia 1.12 and 1.13-rc1, and `BrownFullBasicInit()` makes both testsets pass.

Also adds explicit `using SciMLBase` and `using DiffEqBase: BrownFullBasicInit` since `@safetestset` runs each file in its own fresh module.

## Test plan

- [x] `GROUP=Complex Pkg.test()` on Julia 1.13-rc1 → 102/102 pass locally
- [x] `GROUP=Complex Pkg.test()` on Julia 1.12.6 → 102/102 pass locally
- [x] Runic 1.x format check passes
- [ ] Wait for CI on `lts`, `1`, `pre` Complex jobs

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)