### PR TITLE
fix(boundary): throw ArgumentError for small non-uniform grids to prevent BoundsError

### DIFF
--- a/src/discretization/differential_discretizer.jl
+++ b/src/discretization/differential_discretizer.jl
@@ -96,6 +96,9 @@ function PDEBase.construct_differential_discretizer(
         )
         # A 0th order derivative off the grid is an interpolation
         push!(interp, x => CompleteHalfCenteredDifference(0, max(4, approx_order), dx))
+        if length(dx) < 7
+            throw(ArgumentError("The provided non-uniform grid for dimension $(x) is too small. Boundary extrapolation requires at least 7 points. Please refine your grid."))
+        end
         push!(boundary, x => BoundaryInterpolatorExtrapolator(max(6, approx_order), dx))
     end
 

--- a/src/discretization/differential_discretizer.jl
+++ b/src/discretization/differential_discretizer.jl
@@ -96,8 +96,8 @@ function PDEBase.construct_differential_discretizer(
         )
         # A 0th order derivative off the grid is an interpolation
         push!(interp, x => CompleteHalfCenteredDifference(0, max(4, approx_order), dx))
-        if length(dx) < 7
-            throw(ArgumentError("The provided non-uniform grid for dimension $(x) is too small. Boundary extrapolation requires at least 7 points. Please refine your grid."))
+        if dx isa AbstractVector && length(dx) < 7
+            throw(ArgumentError("The provided non-uniform grid for dimension $(x) is too small (N = $(length(dx))). Boundary extrapolation requires at least 7 points. Please refine your grid."))
         end
         push!(boundary, x => BoundaryInterpolatorExtrapolator(max(6, approx_order), dx))
     end


### PR DESCRIPTION
Fixes #559

As reported in the issue, passing a small non-uniform grid (`length(dx) < 7`) to the discretizer causes an opaque `BoundsError` deep inside `extrapolation_weights.jl` due to a hardcoded minimum stencil length of `6`.

Since solving a PDE on such a coarse grid is mathematically impractical and lacks sufficient points for the required boundary stencil, this PR intercepts the invalid grid size early and throws a descriptive `ArgumentError`. 

This significantly improves the developer experience by explicitly guiding the user to refine their grid, rather than leaving them to debug an internal array bounds crash.