### PR TITLE
Fix for OrdinaryDiffEq 7 / SciMLBase 3 / RecursiveArrayTools 4 (complements #565)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,10 +44,14 @@ julia = "1.10"
 
 [extras]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "NonlinearSolve", "SafeTestsets", "StableRNGs", "Pkg"]
+test = ["Test", "NonlinearSolve", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqSSPRK", "SafeTestsets", "StableRNGs", "Pkg"]

--- a/src/interface/solution/common.jl
+++ b/src/interface/solution/common.jl
@@ -94,6 +94,34 @@ Base.@propagate_inbounds function Base.getindex(
     end
 end
 
+# The PDE solution stores `u` as a `Dict` of dependent variable => array, so the generic
+# `AbstractVectorOfArray` size/length machinery (which iterates `sol.u` expecting a vector
+# of arrays) does not apply. A MOL time series solution is indexed over its saved time
+# points, so report length/size/ndims accordingly.
+Base.length(
+    A::SciMLBase.PDETimeSeriesSolution{T, N, S, D}
+) where {T, N, S, D <: MOLMetadata} = length(A.t)
+
+Base.size(
+    A::SciMLBase.PDETimeSeriesSolution{T, N, S, D}
+) where {T, N, S, D <: MOLMetadata} = (length(A.t),)
+
+Base.ndims(
+    ::SciMLBase.PDETimeSeriesSolution{T, N, S, D}
+) where {T, N, S, D <: MOLMetadata} = 1
+
+Base.axes(
+    A::SciMLBase.PDETimeSeriesSolution{T, N, S, D}
+) where {T, N, S, D <: MOLMetadata} = (Base.OneTo(length(A.t)),)
+
+Base.firstindex(
+    ::SciMLBase.PDETimeSeriesSolution{T, N, S, D}
+) where {T, N, S, D <: MOLMetadata} = 1
+
+Base.lastindex(
+    A::SciMLBase.PDETimeSeriesSolution{T, N, S, D}
+) where {T, N, S, D <: MOLMetadata} = length(A.t)
+
 function Base.display(
         pdesol::SciMLBase.PDESolution{
             T, N, S, D,

--- a/test/pde_systems/MOL_1D_HigherOrder.jl
+++ b/test/pde_systems/MOL_1D_HigherOrder.jl
@@ -2,6 +2,7 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using SciMLBase
 using ModelingToolkit: Differential
 
 # Beam Equation

--- a/test/pde_systems/MOL_1D_Linear_Convection.jl
+++ b/test/pde_systems/MOL_1D_Linear_Convection.jl
@@ -2,6 +2,7 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, DiffEqBase, LinearAlgebra, Test, DomainSets
+using OrdinaryDiffEqLowOrderRK: Euler
 #using Plots
 # Tests
 

--- a/test/pde_systems/MOL_1D_Linear_Convection_WENO.jl
+++ b/test/pde_systems/MOL_1D_Linear_Convection_WENO.jl
@@ -2,6 +2,8 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, DiffEqBase, LinearAlgebra, Test, DomainSets
+using OrdinaryDiffEqSSPRK: SSPRK33
+using OrdinaryDiffEqRosenbrock: Rodas4P
 #using Plots
 # Tests
 

--- a/test/pde_systems/MOL_1D_Linear_Diffusion.jl
+++ b/test/pde_systems/MOL_1D_Linear_Diffusion.jl
@@ -2,6 +2,7 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using OrdinaryDiffEqRosenbrock: Rodas4
 using ModelingToolkit: Differential
 
 # Tests
@@ -218,7 +219,13 @@ end
         for i in 1:length(sol)
             exact = u_exact(x_sol, t_sol[i])
             @test all(isapprox.(u_approx[i, :], exact, atol = 0.01))
-            @test sum(u_approx[i, :]) ≈ 0 atol = 1.0e-10
+            # `sum(u)` is a rectangle-rule proxy for the conserved integral ∫u dx = 0.
+            # The edge-aligned grid places nodes offset by half a step, so its rectangle
+            # sum drifts to ~1e-7 at the default Tsit5 tolerances (the center-aligned grid
+            # stays ~1e-11). 1e-6 still verifies conservation to six digits across both
+            # alignments. (Previously this assertion only ran at i=1 because length(sol)
+            # incorrectly returned 1 for single-variable solutions.)
+            @test sum(u_approx[i, :]) ≈ 0 atol = 1.0e-6
         end
     end
 end

--- a/test/pde_systems/MOL_1D_Linear_Diffusion_NonUniform.jl
+++ b/test/pde_systems/MOL_1D_Linear_Diffusion_NonUniform.jl
@@ -2,6 +2,7 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using OrdinaryDiffEqRosenbrock: Rodas4
 using ModelingToolkit: Differential
 using StableRNGs
 

--- a/test/pde_systems/MOL_1D_NonLinear_Diffusion.jl
+++ b/test/pde_systems/MOL_1D_NonLinear_Diffusion.jl
@@ -5,6 +5,8 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using OrdinaryDiffEqRosenbrock: Rosenbrock32
+using SciMLBase
 using ModelingToolkit: Differential
 # Tests
 @testset "Test 00: Dt(u(t,x)) ~ Dx(u(t,x)^(-1) * Dx(u(t,x)))" begin

--- a/test/pde_systems/MOL_1D_NonLinear_Diffusion_NonUniform.jl
+++ b/test/pde_systems/MOL_1D_NonLinear_Diffusion_NonUniform.jl
@@ -5,6 +5,8 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using OrdinaryDiffEqRosenbrock: Rosenbrock32
+using SciMLBase
 using ModelingToolkit: Differential
 using StableRNGs
 

--- a/test/pde_systems/MOL_1D_PDAE.jl
+++ b/test/pde_systems/MOL_1D_PDAE.jl
@@ -2,6 +2,7 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using OrdinaryDiffEqRosenbrock: Rodas4
 using ModelingToolkit: Differential
 
 # Tests

--- a/test/pde_systems/MOL_Mixed_Deriv.jl
+++ b/test/pde_systems/MOL_Mixed_Deriv.jl
@@ -1,5 +1,6 @@
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets,
     NonlinearSolve
+using SciMLBase
 using ModelingToolkit: Differential
 
 # Broken in MTK - second-order time derivatives cause order lowering in mtkcompile,

--- a/test/pde_systems/MOLtest1.jl
+++ b/test/pde_systems/MOLtest1.jl
@@ -1,4 +1,6 @@
 using ModelingToolkit, MethodOfLines, LinearAlgebra, OrdinaryDiffEq
+using OrdinaryDiffEqRosenbrock: Rodas4
+using OrdinaryDiffEqSDIRK: TRBDF2
 using ModelingToolkit: operation, iscall, arguments
 using DomainSets
 using NonlinearSolve

--- a/test/pde_systems/MOLtest2.jl
+++ b/test/pde_systems/MOLtest2.jl
@@ -1,4 +1,6 @@
 using ModelingToolkit, MethodOfLines, LinearAlgebra, OrdinaryDiffEq
+using OrdinaryDiffEqRosenbrock: Rodas4, Rodas4P
+using SciMLBase
 using ModelingToolkit: operation, iscall, arguments
 using DomainSets
 using NonlinearSolve

--- a/test/pde_systems/brusselator_eq.jl
+++ b/test/pde_systems/brusselator_eq.jl
@@ -1,5 +1,6 @@
 using DomainSets
 using ModelingToolkit, MethodOfLines, LinearAlgebra, OrdinaryDiffEq
+using OrdinaryDiffEqSDIRK: TRBDF2
 
 # using Plots
 

--- a/test/pde_systems/wave_eq_staggered.jl
+++ b/test/pde_systems/wave_eq_staggered.jl
@@ -1,6 +1,7 @@
 using ModelingToolkit, MethodOfLines, DomainSets, Test, Symbolics, SymbolicUtils,
     LinearAlgebra
 using OrdinaryDiffEq
+using OrdinaryDiffEqLowOrderRK: SplitEuler
 
 @testset "1D wave equation, staggered grid, Mixed BC" begin
     @parameters t x


### PR DESCRIPTION
## Fix MethodOfLines for OrdinaryDiffEq 7 / SciMLBase 3 / RecursiveArrayTools 4

**Please ignore until reviewed by @ChrisRackauckas.**

This fixes a pre-existing `master` CI failure on the `Diffusion`, `Diffusion_NU`,
`Nonlinear_Diffusion(_NU)`, `Convection(_WENO)`, `DAE`, `Wave_Eq_Staggered` and related
test groups. `master` already resolves to **OrdinaryDiffEq 7.0.0 / SciMLBase 3.17 /
RecursiveArrayTools 4.3** via the loose `OrdinaryDiffEq = "6, 7"` / `SciMLBase = "2, 3"`
compat, so the breakage reproduces on a clean checkout independently of any dependabot
bump. It also unblocks the DifferentialEquations-8 side of #564 and complements #565
(the DomainSets 0.8 fix). No DomainSets changes are bundled here.

### Two root causes

**1. `length(sol)` / `size(sol)` on a `PDETimeSeriesSolution` (SciMLBase 3 / RAT 4)**

`PDETimeSeriesSolution <: AbstractTimeseriesSolution <: AbstractVectorOfArray`. MoL stores
the solution `u` as a `Dict{Num, Array}`. RAT 4's generic
`Base.size(::AbstractVectorOfArray)` iterates `sol.u` expecting a vector of arrays and
calls `size(u, d)` on each element — but iterating the `Dict` yields `Pair`s, giving
`MethodError: no method matching size(::Pair{Num, Matrix{Float64}}, ::Int64)`. For
single-variable solutions this silently returned `1` (the number of dvs) instead of
erroring, so `for i in 1:length(sol)` loops were quietly only checking `i = 1`.

Fix (`src/interface/solution/common.jl`): define the array interface for the MOL
`PDETimeSeriesSolution` in terms of its saved time points —
`length(sol) == length(sol.t)`, `size(sol) == (length(sol.t),)`, `ndims(sol) == 1`,
plus `axes`/`firstindex`/`lastindex`. This restores the intended time-series semantics
used throughout the tests (`for i in 1:length(sol)`).

**2. OrdinaryDiffEq 7 stopped re-exporting most solver names**

`using OrdinaryDiffEq` (v7) only re-exports a curated subset (`Tsit5`, `Vern6-9`,
`Rosenbrock23`, `Rodas5P`, `FBDF`, `DefaultODEAlgorithm`). Solvers used by the test suite
that are no longer re-exported now live in sub-packages:

| Solver | Sub-package |
| --- | --- |
| `Rodas4`, `Rodas4P`, `Rosenbrock32` | `OrdinaryDiffEqRosenbrock` |
| `TRBDF2` | `OrdinaryDiffEqSDIRK` |
| `SSPRK33` | `OrdinaryDiffEqSSPRK` |
| `Euler`, `SplitEuler` | `OrdinaryDiffEqLowOrderRK` |

Fix: add explicit `using OrdinaryDiffEq<SubPkg>: <Solver>` imports in the affected test
files and add the four sub-packages to the test-only `[extras]` / `[targets]` in
`Project.toml`. `src/` itself references no OrdinaryDiffEq solver names, so no source
change is needed for this half.

### Note on the `Test 03` conservation tolerance

Fixing `length(sol)` exposed a latent test bug in `MOL_1D_Linear_Diffusion.jl` Test 03
(homogeneous Neumann diffusion). The assertion `sum(u) ≈ 0 atol = 1e-10` was previously
only evaluated at `i = 1` (initial condition, exact to ~1e-14) because of the broken
`length`. With `length(sol)` corrected, it now runs at every saved time. The `sum(u)` is a
rectangle-rule proxy for the conserved integral `∫u dx = 0`; the **edge-aligned** grid
places nodes offset by half a step, so its rectangle sum drifts to ~1e-7 at the default
Tsit5 tolerances, while the **center-aligned** grid stays ~1e-11 at the *same* tolerances
(verified locally). The drift is therefore a property of the crude quadrature on the
edge-aligned grid, not solver noise and not a discretization regression. The tolerance is
loosened to `1e-6` (still verifying conservation to six digits) with an explanatory
comment.

### Local verification (Julia 1.11, env resolves OrdinaryDiffEq 7.0.0 / SciMLBase 3.17 / RAT 4.3 / MTK 11.26)

Baseline on clean `master` (`Diffusion` group): 99 passed, **6 errored** — exactly
3× `UndefVarError: Rodas4` and 3× `MethodError: size(::Pair{Num,Matrix}, ::Int)`.

After this PR, run per CI group (`GROUP=… Pkg.test()`):

| Group | Result |
| --- | --- |
| Diffusion | PASS (289/289) |
| Diffusion_NU | PASS |
| Nonlinear_Diffusion | PASS |
| Nonlinear_Diffusion_NU | PASS |
| Convection | PASS |
| Convection_WENO | PASS |
| Wave_Eq_Staggered | PASS |
| Integrals | PASS |

### Remaining failure — out of scope here, NOT silenced

`DAE` (`MOL_1D_PDAE.jl`), `MOL_Interface1` (`MOLtest1.jl`, "Rearranged Robin") and
`Higher_Order` (`MOL_1D_HigherOrder.jl`, KdV soliton) still error with

```
DAE initialization failed: your u0 did not satisfy the initialization requirements,
normresid = … > abstol = 1.0e-6.
```

This is a **separate** SciMLBase-3 behavior change: the default `initializealg` now
runs a strict `CheckInit` that rejects MoL's discretized initial condition (the BC /
algebraic-constraint rows are not satisfied to 1e-6). On clean `master` these same
tests error *earlier* with `UndefVarError: Rodas4` / `UndefVarError: SciMLBase`, so the
init failure was previously masked. Fixing it properly requires either MoL generating a
consistent IC for the constrained rows or threading an `initializealg`
(`BrownFullBasicInit`, which would add an `OrdinaryDiffEqNonlinearSolve` test dep) —
deliberately left for a separate focused PR rather than silenced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
