### PR TITLE
Trapezoidal conservation metric for 1D diffusion (restores strict tol, supersedes #566 loosening)

### DIFF
--- a/test/pde_systems/MOL_1D_Linear_Diffusion.jl
+++ b/test/pde_systems/MOL_1D_Linear_Diffusion.jl
@@ -5,6 +5,23 @@ using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, Domai
 using OrdinaryDiffEqRosenbrock: Rodas4
 using ModelingToolkit: Differential
 
+# Composite trapezoidal-rule weights for a (possibly non-uniform) 1D grid `xs`.
+# `dot(trapezoidal_weights(xs), u)` approximates ∫u dx: each interior node gets the
+# half-spacing on either side, and the two endpoints get a single half-spacing. Unlike a
+# plain `sum(u)` rectangle rule this carries no O(Δx) boundary bias, so it tracks a
+# conserved integral down to the time-integration error rather than the spatial scheme's
+# quadrature error.
+function trapezoidal_weights(xs)
+    n = length(xs)
+    w = zeros(eltype(xs), n)
+    for i in 1:n
+        lo = i == 1 ? zero(eltype(xs)) : (xs[i] - xs[i - 1]) / 2
+        hi = i == n ? zero(eltype(xs)) : (xs[i + 1] - xs[i]) / 2
+        w[i] = lo + hi
+    end
+    return w
+end
+
 # Tests
 @testset "Test 00: Dt(u(t,x)) ~ Dxx(u(t,x))" begin
     # Method of Manufactured Solutions
@@ -215,17 +232,21 @@ end
         # end
 
         u_approx = sol[u(t, x)]
+        # Homogeneous Neumann BCs make ∫u dx a conserved quantity; here ∫₀^π cos(x) dx = 0.
+        # Integrate with composite trapezoidal weights built from the actual grid spacing
+        # (so it is correct on both the center-aligned and the half-step-offset edge-aligned
+        # grids). A plain `sum(u)` rectangle rule carries an O(Δx) boundary bias that drifts
+        # to ~1e-7 on the edge-aligned grid; the trapezoidal integral instead conserves down
+        # to the Tsit5 time-integration error (~6e-10 edge / ~4e-13 center at the default
+        # tolerances, both → ~1e-15 when the solver tolerance is tightened), so a strict
+        # atol holds honestly.
+        w = trapezoidal_weights(x_sol)
+        integral0 = dot(w, u_approx[1, :])
         # Test against exact solution
         for i in 1:length(sol)
             exact = u_exact(x_sol, t_sol[i])
             @test all(isapprox.(u_approx[i, :], exact, atol = 0.01))
-            # `sum(u)` is a rectangle-rule proxy for the conserved integral ∫u dx = 0.
-            # The edge-aligned grid places nodes offset by half a step, so its rectangle
-            # sum drifts to ~1e-7 at the default Tsit5 tolerances (the center-aligned grid
-            # stays ~1e-11). 1e-6 still verifies conservation to six digits across both
-            # alignments. (Previously this assertion only ran at i=1 because length(sol)
-            # incorrectly returned 1 for single-variable solutions.)
-            @test sum(u_approx[i, :]) ≈ 0 atol = 1.0e-6
+            @test dot(w, u_approx[i, :]) ≈ integral0 atol = 1.0e-9
         end
     end
 end


### PR DESCRIPTION
## Summary

This supersedes the **conservation-check tolerance loosening introduced in #566** with a proper grid-weighted (trapezoidal) quadrature, so the assertion in Test 03 of `test/pde_systems/MOL_1D_Linear_Diffusion.jl` holds at a strict tolerance again — honestly, without any fudge.

#566 (the OrdinaryDiffEq 7 / SciMLBase 3 / RecursiveArrayTools 4 migration) fixed `length(sol)` for single-variable PDE solutions, which made the per-timestep mass-conservation check actually run at every saved time instead of only at `i = 1`. Once it ran for the whole trajectory, the crude `sum(u)` rectangle-rule proxy was exposed: on the **edge-aligned** grid (nodes sit half a step *outside* the domain) the rectangle rule has an O(Δx) boundary bias and drifts to ~1e-7, so #566 relaxed `atol` from `1e-10` to `1e-6` with an explanatory comment. That was a band-aid; this PR removes it.

## What changed

- Added a small `trapezoidal_weights(xs)` helper that builds composite trapezoidal weights from the **actual grid spacing** (each interior node gets the half-spacing on either side; the two endpoints get a single half-spacing). It is correct on the center-aligned grid, the half-step-offset edge-aligned grid, and non-uniform grids.
- Replaced `@test sum(u_approx[i, :]) ≈ 0 atol = 1e-6` with `@test dot(w, u_approx[i, :]) ≈ integral0 atol = 1e-9`, where `integral0 = dot(w, u_approx[1, :])` is the trapezoidal integral of the initial condition. Comparing to the conserved initial integral (rather than hardcoding `0`) keeps the metric meaningful for any IC.

## Why the strict tolerance is honest, not a refit

The rectangle-rule drift was a **quadrature artifact, not a conservation defect of the scheme**. The MoL semi-discretization with homogeneous Neumann BCs conserves the trapezoidal integral exactly at the spatial level; the only residual is the time integrator's error. Measured `max|∫u dx|` over the trajectory:

| grid | Tsit5 tol = default (1e-6/1e-3) | Tsit5 tol = 1e-12/1e-12 |
|------|---------------------------------|--------------------------|
| center-aligned (300 pts) | 4.13e-13 | 6.79e-16 |
| edge-aligned (301 pts)   | 5.76e-10 | 7.87e-16 |

Tightening the solver tolerance drives the residual to machine precision on both grids, confirming it is bounded by time integration. For comparison the old `sum(u)` rectangle rule hit `9.8e-11` (center) / `1.10e-7` (edge) at the default tolerances.

The test uses default Tsit5 tolerances, so the realistic worst case is the edge-aligned `5.76e-10`. The new `atol = 1e-9` sits just above that (≈1.7x headroom on a deterministic computation) and is **1000x tighter than #566's `1e-6`**; the center-aligned grid passes with ~4 orders of margin. Both grid configurations (`discretization` and `discretization_edge`) are exercised by the existing `for disc in [...]` loop.

## Local test evidence

```
$ GROUP=Diffusion julia +1.11 -e 'using Pkg; Pkg.test()'
...
Test Summary:                                      | Pass  Total      Time
MOLFiniteDifference Interface: 1D Linear Diffusion |  289    289  10m49.1s
     Testing MethodOfLines tests passed
```

289/289 pass with the strict `atol = 1e-9`, both grid alignments, no skips/`@test_broken`/loosening anywhere.

## Stacking

This is **stacked on #566** and includes its commits (notably the `length`/`size` solution-interface fix that makes this conservation check run at every timestep). It should land **with or after #566**. The diff unique to this PR is a single test file.

## Notes

- Refs #564, #566.
- Please ignore until reviewed by @ChrisRackauckas.
