### PR TITLE
Format: apply Runic to fix format check

### DIFF
--- a/test/pde_systems/MOL_1D_Linear_Convection_NonUniform.jl
+++ b/test/pde_systems/MOL_1D_Linear_Convection_NonUniform.jl
@@ -7,7 +7,7 @@ using ModelingToolkit: Differential
 @variables u(..)
 
 const L2_RTOL = 0.2
-const MASS_RTOL = 5e-2
+const MASS_RTOL = 5.0e-2
 
 cell_widths(x::AbstractVector) = [diff(x)...; diff(x)[end]]
 


### PR DESCRIPTION
Formatting-only PR to fix the failing Runic format check.

The repo's `format-check` CI runs Runic (`fredrikekre/runic-action@v1` / `SciML/.github/.github/workflows/runic.yml@v1`) with default settings (extensions `jl`, no docstring formatting). The check is currently failing.

This applies Runic v1.7.0 (the version `version: '1'` resolves to) in place over all git-tracked `.jl` files, matching exactly how CI selects and formats files. No semantic/code changes — verified that diffs are whitespace/formatting only (`git diff --ignore-all-space` is empty for the larger reindent). Re-running Runic in `--check` mode after formatting passes with exit code 0.

Ignore until reviewed by @ChrisRackauckas.