### PR TITLE
Fix QA CI group: activate test/qa env via run_tests

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,3 @@
-using Pkg
-Pkg.activate(@__DIR__)
-Pkg.instantiate()
-
 using MethodOfLines, Aqua, JET, Test
 
 # Aqua/JET findings tracked at https://github.com/SciML/MethodOfLines.jl/issues/574

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,6 @@ run_tests(;
         "Convection_NU" => joinpath(@__DIR__, "Convection_NU", "MOL_1D_Linear_Convection_NonUniform.jl"),
         "Wave_Eq_Staggered" => joinpath(@__DIR__, "Wave_Eq_Staggered", "wave_eq_staggered.jl"),
     ),
-    qa = joinpath(@__DIR__, "qa", "qa.jl"),
+    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
     all = FUNCTIONAL_GROUPS,
 )


### PR DESCRIPTION
## Problem

The **QA** test group is red on `master` (Julia 1, lts, and pre matrix jobs):

```
QA: Error During Test at SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: ArgumentError: Package Pkg not found in current path.
  ...
  in expression starting at .../test/qa/qa.jl:1
```

## Root cause

`MethodOfLines.jl` was converted to the SciMLTesting v1.2 folder model in #576. SciMLTesting runs each group's body inside a `@safetestset` (a fresh module evaluated in the **root** test environment). `test/qa/qa.jl` still carried the legacy self-activation preamble:

```julia
using Pkg
Pkg.activate(@__DIR__)
Pkg.instantiate()
```

`Pkg` is not a dependency of the root `[targets].test`, so `using Pkg` fails on line 1 *before* the activation can run.

Under SciMLTesting v1.2, per-group environment activation is the harness's responsibility. `runtests.jl` passed the qa group as a bare file path (`qa = joinpath(@__DIR__, "qa", "qa.jl")`) with no declared `env`, so `run_tests` never activated `test/qa/Project.toml`.

## Fix

Two minimal changes, matching the convention used by the already-converted `Integrals.jl` / `HighDimPDE.jl`:

1. `test/runtests.jl` — declare the qa env so `run_tests` activates it (`Pkg.activate` + `Pkg.develop` the package + `Pkg.instantiate`) before evaluating the body:
   ```julia
   qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
   ```
2. `test/qa/qa.jl` — drop the redundant `using Pkg; Pkg.activate(@__DIR__); Pkg.instantiate()` preamble.

The pre-existing `@test_broken` markers (tracked at #574) are untouched.

## Local verification

`GROUP=QA julia +release Pkg.test(...)` on Julia 1.12 (the failing CI matrix Julia version):

```
Test Summary: | Pass  Broken  Total   Time
QA            |    3       6      9  55.7s
     Testing MethodOfLines tests passed
```

The `Pkg not found` error is gone, the qa env resolves/instantiates, Aqua + JET load, and the group passes.

## Scope

This PR fixes **only** the QA group. The other red checks on `master` (DAE / Higher_Order / MOL_Interface1 / 2D_Diffusion test groups, Downgrade, docs) fail for unrelated genuine breakages — DAE initialization (`your u0 did not satisfy the initialization requirements`), a SymbolicUtils nonlinear-laplacian rule-application failure, and `UndefVarError`s in doc examples (`QNDF`, `DynamicSS`) — which are out of scope here.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
