### PR TITLE
Throw clear ArgumentError for grids too coarse for boundary stencil

### DIFF
--- a/src/discretization/schemes/extrapolation_weights.jl
+++ b/src/discretization/schemes/extrapolation_weights.jl
@@ -82,6 +82,9 @@ function BoundaryInterpolatorExtrapolator(
     boundary_stencil_length = approximation_order
     boundary_point_count = endpoint = div(stencil_length, 2)
     len = length(x)
+    if len < boundary_stencil_length + 1
+        throw(ArgumentError("grid has $len points, but the boundary extrapolation stencil needs at least $(boundary_stencil_length + 1). Provide a finer grid for this variable."))
+    end
     dx = [x[i + 1] - x[i] for i in 1:(length(x) - 1)]
     interior_x = (endpoint + 1):(len - endpoint)
     low_boundary_x = [zero(T); cumsum(dx[1:(boundary_stencil_length - 1)])]

--- a/test/Convection_NU/MOL_1D_Linear_Convection_NonUniform.jl
+++ b/test/Convection_NU/MOL_1D_Linear_Convection_NonUniform.jl
@@ -380,6 +380,21 @@ end
     end
 end
 
+@testset "Coarse grid error" begin
+    L = 1.0
+    v = 1.0
+    tspan = (0.0, 0.25)
+    u0 = x -> sin(2π * x / L)
+    u_exact = (x, t) -> translating_sine_exact(x, t, v, L)
+
+    # A grid this coarse cannot fit the boundary extrapolation stencil. It used
+    # to fail with an opaque BoundsError; now it reports an ArgumentError.
+    xgrid = [0.0, 0.1, 0.3, 0.6, 0.8, 1.0]
+    @test_throws ArgumentError solve_mms_advection(;
+        xgrid, v, tspan, u0, u_exact,
+    )
+end
+
 @testset "Periodic boundary conditions" begin
     L = 1.0
     v = 1.0


### PR DESCRIPTION
Fixes #559. On a non-uniform grid with fewer than approximation_order + 1 points, the boundary extrapolator indexed dx out of range and failed with an opaque BoundsError deep in extrapolation_weights.jl. This adds an explicit length check up front so the user gets a clear message telling them the grid is too coarse for the boundary stencil. Added a regression test alongside the existing non-uniform convection cases.