### PR TITLE
fix(discretization): fold symbolic initial conditions for MTK v1.45 compatibility

### DIFF
--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -8,7 +8,8 @@ using ModelingToolkit: get_unknowns,
     get_ivs
 using SymbolicIndexingInterface
 using SymbolicUtils, Symbolics
-using Symbolics: unwrap, symbolic_linear_solve, expand_derivatives, diff2term
+using Symbolics: unwrap, symbolic_linear_solve, expand_derivatives, diff2term,
+    symbolic_to_float
 using SymbolicUtils: operation, arguments, iscall, getmetadata, unwrap_const
 using IfElse
 using StaticArrays

--- a/src/discretization/generate_ic_defaults.jl
+++ b/src/discretization/generate_ic_defaults.jl
@@ -14,14 +14,17 @@ function PDEBase.generate_ic_defaults(
             D = ic.order == 0 ? identity : (Differential(t)^ic.order)
             defaultvars = D.(s.discvars[depvar(ic.u, s)])
             broadcastable_rhs = [symbolic_linear_solve(ic.eq, D(ic.u))]
-            out = pde_substitute.(
+            rhs_vals = pde_substitute.(
                 broadcastable_rhs, Dict.(valmaps(s, depvar(ic.u, s), ic.depvars, indexmap))
             )
-            vec(
-                defaultvars .=> pde_substitute.(
-                    broadcastable_rhs, Dict.(valmaps(s, depvar(ic.u, s), ic.depvars, indexmap))
-                )
-            )
+            # Substitution in SymbolicUtils v4 no longer constant-folds function calls, so an
+            # IC like `u(0, x) ~ cos(x)` produces stuck terms like `cos(0.108...)`. MTK v11's
+            # `varmap_to_vars` requires literal constants in the u0 map and reports any
+            # unfolded value as "Initial condition underdefined". `symbolic_to_float` folds
+            # fully-constant expressions to numbers and leaves genuinely symbolic values
+            # (e.g. parameter-dependent ICs) untouched for MTK to resolve downstream.
+            fold(v) = v isa Number ? v : symbolic_to_float(v)
+            vec(defaultvars .=> fold.(rhs_vals))
         end
     else
         u0 = []

--- a/src/discretization/generate_ic_defaults.jl
+++ b/src/discretization/generate_ic_defaults.jl
@@ -17,12 +17,7 @@ function PDEBase.generate_ic_defaults(
             rhs_vals = pde_substitute.(
                 broadcastable_rhs, Dict.(valmaps(s, depvar(ic.u, s), ic.depvars, indexmap))
             )
-            # Substitution in SymbolicUtils v4 no longer constant-folds function calls, so an
-            # IC like `u(0, x) ~ cos(x)` produces stuck terms like `cos(0.108...)`. MTK v11's
-            # `varmap_to_vars` requires literal constants in the u0 map and reports any
-            # unfolded value as "Initial condition underdefined". `symbolic_to_float` folds
-            # fully-constant expressions to numbers and leaves genuinely symbolic values
-            # (e.g. parameter-dependent ICs) untouched for MTK to resolve downstream.
+
             fold(v) = v isa Number ? v : symbolic_to_float(v)
             vec(defaultvars .=> fold.(rhs_vals))
         end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -44,7 +44,7 @@ run_qa(
                 :Interval, :add_metadata!, :error_analysis, :get_ops, :insert, :remove,
                 :sym_dot, :unitindex, :unitindices, :update_varmap!, :vcat!,
                 # non-public in Symbolics:
-                :diff2term,
+                :diff2term, :symbolic_to_float,
             ),
         ),
         all_qualified_accesses_are_public = (;


### PR DESCRIPTION
## Root Cause
MTKBase v1.45.1-era `varmap_to_vars` now strictly enforces `SU.isconst` checks on `u0` map values. Meanwhile, MOL's `generate_ic_defaults` builds `u0` values via substitution (here via `pde_substitute`), which leaves function-call ICs as unfolded symbolic trees rather than literal constants (e.g., `cos(0.108)` remains a symbolic tree). This mismatch triggers `Initial condition underdefined` errors during `discretize()`. ICs containing function calls fail, while plain/constant ICs (e.g., Burgers, Integrals) continue to pass.

## Fix
- **`generate_ic_defaults.jl`**: Wrapped substituted `u0` values in `Symbolics.symbolic_to_float`. This safely folds constant expressions into numbers while preserving genuinely symbolic/parametric expressions for MTK to resolve. Also removed a dead `out = ...` block.
- **`MethodOfLines.jl`**: Imported `symbolic_to_float`.
- **`qa.jl`**: Added `:symbolic_to_float` to the `ExplicitImports` ignore list.

*Verification*: Verified locally on failing groups. Diffusion, Components, Convection_WENO, Sol_Interface, Complex, and Wave_Eq_Staggered are now green. No regressions in previously passing groups (Burgers, Integrals, Stationary).

## Reviewer Note
- **QA / Non-Public API**: `symbolic_to_float` is not public API, so I added it to the QA ignore list (following the `:diff2term` precedent). Since public APIs like `simplify` or `substitute` no longer fold constants in Symbolics v7, this was the safest workaround. If there is a preferred public alternative, please let me know and I will gladly switch! *(Note: I did not bisect the exact MTKBase commit, but the failure window aligns perfectly with the v1.45.1 release and the new `SU.isconst` checks).*
- **DAE Group**: Still fails, but due to an independent cause. OrdinaryDiffEq's stricter `CheckInit` now rejects the O(dx²) residual in `MOL_1D_PDAE.jl`. Passing `initializealg = BrownFullBasicInit()` fixes it locally (matching the `schroedinger.jl` precedent), but I left it out of this PR to strictly contain scope.