### PR TITLE
Bump version to 0.11.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "0.11.13"
+version = "0.11.14"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.11.13 -> 0.11.14) to release unreleased commits on `master` via JuliaRegistrator.