### PR TITLE
fix(tests): BrownFullBasicInit for PDAE Dirichlet DAE test

### DIFF
--- a/test/DAE/MOL_1D_PDAE.jl
+++ b/test/DAE/MOL_1D_PDAE.jl
@@ -4,6 +4,7 @@
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
 using OrdinaryDiffEqRosenbrock: Rodas4
 using ModelingToolkit: Differential
+using DiffEqBase: BrownFullBasicInit
 
 # Tests
 @testset "Dt(u(t,x)) ~ Dxx(u(t,x)), 0 ~ Dxx(v(t,x)) + sin(x), Dirichlet BCs" begin
@@ -51,7 +52,7 @@ using ModelingToolkit: Differential
     # Convert the PDE problem into an ODE problem
     prob = discretize(pdesys, discretization)
     # Solve ODE problem
-    sol = solve(prob, Rodas4(), saveat = 0.1)
+    sol = solve(prob, Rodas4(), saveat = 0.1, initializealg = BrownFullBasicInit())
 
     x_sol = sol[x]
     t_sol = sol[t]


### PR DESCRIPTION
## Summary

Fixes the failing master CI test group **DAE** (all Julia versions).

- **Failing test:** `Dt(u(t,x)) ~ Dxx(u(t,x)), 0 ~ Dxx(v(t,x)) + sin(x), Dirichlet BCs` in `test/DAE/MOL_1D_PDAE.jl`
- **Error:** `DAE initialization failed: ... normresid ≈ 0.0039 > abstol = 1e-6` under OrdinaryDiffEq's default `CheckInit`
- **Fix:** Pass `initializealg = BrownFullBasicInit()` at `solve`, matching `test/Complex/schroedinger.jl`

This is a minimal, test-scoped fix for one failing test. A broader package-level fallback is proposed in #585; this PR does not depend on that.

## Verification

Locally on Julia 1.10.11:

```
ENV["GROUP"]="DAE"; Pkg.test("MethodOfLines")
# Test Summary: | Pass  Total
# DAE           |   22     22
```

Without the change, solve throws on initialization; with it, accuracy checks against the manufactured solution pass (`atol = 0.01`).

## Notes

**Please ignore this PR until reviewed by @ChrisRackauckas.**