### PR TITLE
fix(tests): BrownFullBasicInit for KdV single-soliton test

### DIFF
--- a/test/Higher_Order/MOL_1D_HigherOrder.jl
+++ b/test/Higher_Order/MOL_1D_HigherOrder.jl
@@ -4,6 +4,7 @@
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
 using SciMLBase
 using ModelingToolkit: Differential
+using DiffEqBase: BrownFullBasicInit
 
 # Beam Equation
 #! Broken due to overlapping inner corner bc eqs - determine state sharing heuristic; sort by dorder and give precedence to higher
@@ -131,7 +132,7 @@ end
     @named pdesys = PDESystem(eq, bcs, domains, [x, t], [u(x, t)])
     prob = discretize(pdesys, discretization)
 
-    sol = solve(prob, FBDF(), saveat = 0.1)
+    sol = solve(prob, FBDF(), saveat = 0.1, initializealg = BrownFullBasicInit())
 
     @test SciMLBase.successful_retcode(sol)
 


### PR DESCRIPTION
## Summary

Fixes the failing master CI test group **Higher_Order** (all Julia versions).

- **Failing test:** `KdV Single Soliton equation` in `test/Higher_Order/MOL_1D_HigherOrder.jl`
- **Error:** `DAE initialization failed: ... normresid ≈ 3.56e-5 > abstol = 1e-6` under OrdinaryDiffEq's default `CheckInit`
- **Fix:** Pass `initializealg = BrownFullBasicInit()` at `solve`, matching `test/Complex/schroedinger.jl`

Other tests in this file (`Test 00` beam, beam-with-velocity) are unchanged. Beam-with-velocity already succeeds without special initialization.

This is a minimal, test-scoped fix. A broader package-level fallback is proposed in #585.

## Verification

Locally on Julia 1.10.11:

```
ENV["GROUP"]="Higher_Order"; Pkg.test("MethodOfLines")
# Test Summary: | Pass  Broken  Total
# Higher_Order  |    1       2      3
```

## Notes

**Please ignore this PR until reviewed by @ChrisRackauckas.**