### PR TITLE
fix(tests): BrownFullBasicInit for Rearranged Robin test

### DIFF
--- a/test/MOL_Interface1/MOLtest1.jl
+++ b/test/MOL_Interface1/MOLtest1.jl
@@ -6,6 +6,7 @@ using DomainSets
 using NonlinearSolve
 using StableRNGs
 using Test
+using DiffEqBase: BrownFullBasicInit
 
 # # Define some variables
 @testset "Heat Equation 1D 2 variables" begin
@@ -225,7 +226,7 @@ end
     # Convert the PDE problem into an ODE problem
     prob = discretize(pdesys, discretization)
 
-    sol = solve(prob, Rodas4())
+    sol = solve(prob, Rodas4(), initializealg = BrownFullBasicInit())
 end
 
 @testset "Array u" begin


### PR DESCRIPTION
## Summary

Fixes the failing master CI test group **MOL_Interface1** (all Julia versions).

- **Failing test:** `Rearranged Robin` in `test/MOL_Interface1/MOLtest1.jl`
- **Error:** `DAE initialization failed: ... normresid ≈ 0.559 > abstol = 1e-6` under OrdinaryDiffEq's default `CheckInit`
- **Fix:** Pass `initializealg = BrownFullBasicInit()` at `solve`, matching `test/Complex/schroedinger.jl`

Other interface tests in this file are unchanged.

This is a minimal, test-scoped fix. A broader package-level fallback is proposed in #585.

## Verification

Locally on Julia 1.10.11:

```
ENV["GROUP"]="MOL_Interface1"; Pkg.test("MethodOfLines")
# Test Summary:  |   Time
# MOL_Interface1 | None  7m56.2s
# Testing MethodOfLines tests passed
```

Without the change, solve throws on initialization; with it, the group completes successfully.

## Notes

**Please ignore this PR until reviewed by @ChrisRackauckas.**