### PR TITLE
fix: Resolve Symbolics TypeError in Downgrade CI

### DIFF
--- a/src/discretization/schemes/WENO/nonuniform_weno.jl
+++ b/src/discretization/schemes/WENO/nonuniform_weno.jl
@@ -48,7 +48,7 @@ end
 @inline _dot3(w::SVector{3}, a, b, c) = w[1] * a + w[2] * b + w[3] * c
 
 @inline _beta_nonneg(val::T) where {T <: AbstractFloat} = max(val, zero(val))
-@inline _beta_nonneg(val) = IfElse.ifelse(val < zero(val), zero(val), val)
+@inline _beta_nonneg(val) = max(val, zero(val))
 
 # Smoothness indicator β_k (Jiang & Shu 1996), Simpson quadrature over cell i.
 @inline function _substencil_beta_r(


### PR DESCRIPTION
**Description**
This PR fixes the `TypeError` in the non-uniform WENO scheme that blocks the Downgrade CI.

**Fix Details**
* In Julia 1.10 LTS, `IfElse.ifelse` falls back to `Core.ifelse`, which fails when evaluating a `Symbolics.Num`.
* Replaced the generic `_beta_nonneg` fallback with `max(val, zero(val))`. This is natively supported by Symbolics and mathematically equivalent.
* The `AbstractFloat` dispatch is fully preserved to maintain zero-allocation.
* *WENO tests pass locally (48/48).*

**Note on Current CI Failure**
With the WENO issue resolved, the Downgrade CI now progresses but fails later in `test/Brusselator/brusselator_eq.jl` due to numerical drift in older `OrdinaryDiffEq` solvers. To keep this PR focused strictly on the WENO fix, I left the Brusselator tolerances untouched. That can be addressed in a separate PR if needed.