### PR TITLE
Release prep: bump MethodOfLines to 0.11.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "0.11.14"
+version = "0.11.15"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes since 0.11.14 (docstrings added, an already-broken `grid_align` export removed, and test-only SciMLTesting compat bump).