### PR TITLE
Fix QA self-source setup

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -4,9 +4,6 @@ MethodOfLines = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-MethodOfLines = {path = "../.."}
-
 [compat]
 JET = "0.9,0.10,0.11"
 SciMLTesting = "2.1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -7,6 +7,7 @@ run_qa(
     MethodOfLines;
     explicit_imports = true,
     api_docs_kwargs = (; rendered = true),
+    aqua_kwargs = (; persistent_tasks = (; tmax = 300)),
     # Aqua sub-checks with genuine findings, marked broken pending fixes (issue #574):
     #   :ambiguities       — 48 method ambiguities involving MethodOfLines methods
     #   :stale_deps        — OrdinaryDiffEq declared but not loaded (uses split subpackages)


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Remove the redundant local self-source entry from `test/qa/Project.toml`.
- Keep SciMLTesting public API docs QA active via `api_docs_kwargs = (; rendered = true)`.
- Keep Aqua persistent-task checking enabled, but give MethodOfLines' wrapper precompile enough time to exit by setting `persistent_tasks.tmax = 300`.

## Validation
- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_runic timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic_env -e 'using Runic; exit(Runic.main(["--check", "test/qa/qa.jl"]))'`
- `GROUP=QA JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_methodoflines_qa timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'`
- QA Project source/path scan: `PASS: no [sources] headers or path entries found in QA Project.toml files`