### PR TITLE
Release prep: bump version to 0.11.16

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "0.11.15"
+version = "0.11.16"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

Bumps `MethodOfLines` from 0.11.15 to 0.11.16 to release two unreleased commits currently sitting on `master`:

- `394341f` fix(WENO): replace `IfElse.ifelse` with `max` in generic `_beta_nonneg` for LTS Symbolics compat (#590) — fixes a `TypeError` on Julia 1.10 LTS where `IfElse.ifelse` falls back to `Core.ifelse`, which fails when evaluated with `Symbolics.Num`. Mathematically equivalent, zero-allocation `AbstractFloat` dispatch preserved. This was blocking Downgrade CI.
- `9d25434` Fix QA self-source setup (#595) — test-only change (removes a `[sources]` self-path override in `test/qa/Project.toml` and adds an `aqua_kwargs` tmax setting in `test/qa/qa.jl`).

## Bump type: PATCH (0.11.15 -> 0.11.16)

No new public API, no behavior change for users, no `[compat]` changes. The WENO change is a backward-compatible bugfix (numerically equivalent branch-free replacement) and the other change only touches test infrastructure. Default per the release process is PATCH absent evidence of new functionality, and there is none here.

## Compat bounds

Not touched. The diff since the last release does not add usage of any new SciML-ecosystem API, and existing `[compat]` bounds already look consistent with the code.