### PR TITLE
test: align Brusselator reference grid

### DIFF
--- a/test/Brusselator/brusselator_eq.jl
+++ b/test/Brusselator/brusselator_eq.jl
@@ -76,7 +76,7 @@ using OrdinaryDiffEqSDIRK: TRBDF2
     t = sol[t]
     # Solve reference problem
 
-    xyd_brusselator = range(0, stop = 1, length = N)
+    xyd_brusselator = range(0, step = dx, length = N)
     brusselator_f(x, y, t) = (((x - 0.3)^2 + (y - 0.6)^2) <= 0.1^2) * (t >= 1.1) * 5.0
     limit(a, N) = a == N + 1 ? 1 : a == 0 ? N : a
     function brusselator_2d_loop(du, u, p, t)


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

The Brusselator reference problem used

```julia
range(0, stop = 1, length = N)
```

which has spacing `1/(N-1)`, while the periodic MOL discretization uses `dx = 1/N`. The mismatched grid also changed the reference diffusion coefficient, initial values, and forcing coordinates, so the nonlinear trajectories diverged at later save points.

This uses the same `dx` and number of points for both systems:

```julia
range(0, step = dx, length = N)
```

No tolerance, solver, skip, or broken-test setting changes.

## CI context

Current `master` downgrade run 29218306213 and MOL #594's downgrade job both reproduce:

```text
Brusselator | 1116 pass | 38 fail | 1154 total
```

Source bisect found:

- Last green runner state: `4feb46f5`
- First failing runner state: `6de450dd` (made the latent test defect visible)
- Original mismatched grid: `0e869988`

## Local verification

- Exact downgrade manifest, Julia 1.10.11: **1154/1154**
- Latest-compatible environment with PDEBase 0.1.29 and NonlinearSolveBase 2.34.1: **1154/1154**
- Runic full-repository check: clean
- `git diff --check`: clean

## Process

1. Reproduced the current `master` downgrade failure locally.
2. Bisected the runner transition that exposed it.
3. Compared MOL's periodic grid with the manual reference grid.
4. Applied the one-line grid correction and reran both downgrade and current environments.