### PR TITLE
Enforce PDESystemLibrary downstream failures

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -19,5 +19,4 @@ jobs:
       repo: "${{ matrix.package.repo }}"
       group: "${{ matrix.package.group }}"
       julia-version: "1"
-      continue-on-error: true  # PDESystemLibrary tests have pre-existing failures, see issue
     secrets: "inherit"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Audit finding

The PDESystemLibrary downstream job selected a real, populated `Core` group, but the reusable workflow call set `continue-on-error: true`. That made any resolver or test failure non-blocking even though the current downstream suite passes.

## Change

Remove failure suppression so the downstream job remains green only when the selected tests complete successfully.

## Local verification

- Runic: workflow formatted cleanly.
- actionlint: workflow passed static validation.
- Workflow-equivalent Julia 1.12.6 run: developed this MethodOfLines checkout into PDESystemLibrary and ran `GROUP=Core Pkg.test()`.
- Result: exit code 0; `Core/mol_test.jl | 426 pass, 1 broken, 427 total` in 23m51s; Pkg reported `PDESystemLibrary tests passed`.

The existing broken test remains visible and unchanged; this PR does not skip, loosen, or silence it.