### PR TITLE
feat: add interface and periodic boundary support for non-uniform WENO

### DIFF
--- a/docs/src/advection_schemes.md
+++ b/docs/src/advection_schemes.md
@@ -24,7 +24,11 @@ Problems which require this scheme may also benefit from a [Strong-Stability-Pre
 
 Problems with first order derivatives which multiply one another will need to use this scheme over the upwind scheme.
 
-Supports only first order derivatives, other odd order derivatives are unsupported with this scheme. At present, does not support Nonuniform grids, though this is a planned feature.
+Supports only first order derivatives, other odd order derivatives are unsupported with this scheme.
+
+Nonuniform grids are supported: when a grid vector is supplied for a spatial variable, a node-centered nonuniform WENO-5 reconstruction (4th order accurate in smooth regions) is used, with one-sided reconstructions at physical boundaries.
+
+Periodic and interface boundary conditions are supported on nonuniform grids. Stencils that wrap across a periodic boundary or an interface between two domains are evaluated with the exact physical coordinates of the connected grid, so no accuracy is lost at the seam. The grids on either side of an interface do not need to match when a nonuniform grid vector is supplied for both connected variables. This applies to first-order (advection) derivatives only: systems with spatial derivative orders above 1 in variables connected by a mismatched-grid interface are rejected at discretization time, since higher-order stencils are not coordinate-aware at the interface.
 
 Specified on pages 8-9 of [this document](https://repository.library.brown.edu/studio/item/bdr:297524/PDF/)
 

--- a/docs/src/boundary_conditions.md
+++ b/docs/src/boundary_conditions.md
@@ -126,6 +126,8 @@ v(t, x, y_max) ~ u(t, x_max, y)
 
 Please note that if you want to use a periodic condition on a dimension with WENO schemes, please use a periodic condition on all variables in that dimension.
 
+Periodic conditions are also supported with `WENOScheme()` on nonuniform grids; wrapped stencils use the exact periodically shifted grid coordinates.
+
 ## Interfaces
 
 You may want to connect regions with differing dynamics together, to do this follow the following example, splitting the variable that spans these domains:
@@ -164,3 +166,5 @@ domains = [t ∈ Interval(0.0, 0.15),
 ```
 
 Note that if you want to use a higher order interface condition, this may not work if you have no simple condition of the form `c1(t, 0.5) ~ c2(t, 0.5)`.
+
+Interfaces require the connected variables to use the same step size, except when `WENOScheme()` is used with nonuniform grid vectors supplied for both connected variables, in which case the grids may differ: advection stencils that cross the interface are evaluated with the exact physical coordinates of the neighbouring grid. This exception covers first-order (advection) derivatives only — systems containing higher-order spatial derivatives (e.g. diffusion) in the connected variables are rejected with an error at discretization time.

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -16,12 +16,23 @@ function PDEBase.interface_errors(
     end
 end
 
+# Single predicate shared by check_boundarymap and validate_interface_orders.
+function mismatched_interface_dxs(b, discretization::MOLFiniteDifference)
+    return discretization.dxs[Num(b.x)] != discretization.dxs[Num(b.x2)]
+end
+
 function PDEBase.check_boundarymap(boundarymap, discretization::MOLFiniteDifference)
     bs = filter_interfaces(flatten_vardict(boundarymap))
+    ascheme = discretization.advection_scheme
     for b in bs
-        dx1 = discretization.dxs[Num(b.x)]
-        dx2 = discretization.dxs[Num(b.x2)]
-        if dx1 != dx2
+        if mismatched_interface_dxs(b, discretization)
+            # NU FunctionalScheme uses exact interface coordinates (bcoord) for advection;
+            # dx match waived. Non-advection orders are rejected by validate_interface_orders.
+            if ascheme isa FunctionalScheme && ascheme.is_nonuniform &&
+                    discretization.dxs[Num(b.x)] isa AbstractVector &&
+                    discretization.dxs[Num(b.x2)] isa AbstractVector
+                continue
+            end
             throw(ArgumentError("The step size of the connected variables $(b.x) and $(b.x2) must be the same. If you need nonuniform interface boundaries please post an issue on GitHub."))
         end
     end

--- a/src/discretization/interface_boundary.jl
+++ b/src/discretization/interface_boundary.jl
@@ -32,7 +32,7 @@ end
 
 @inline function _wrapperiodic(I, N, j, l)
     I1 = unitindex(N, j)
-    # -1 because of the relation u[1] ~ u[end]
+    # shift l-1: u[1] ~ u[end]
     if I[j] <= 1
         I = I + I1 * (l - 1)
     elseif I[j] > l
@@ -42,7 +42,7 @@ end
 end
 
 """
-Allow stencils indexing over periodic boundaries. Index through this function.
+Wrap stencil indices across interface/periodic boundaries.
 """
 
 function wrapinterface(
@@ -84,7 +84,6 @@ function _wrapinterface(I, s, b::InterfaceBoundary{Val{false}(), Val{true}()}, j
         l2 = length(s, b.x2)
         N = ndims(u, s)
         I1 = unitindex(N, j)
-        # update index
         I = I + (l2 - 1) * I1
         I = RefCartesianIndex(I, discu2)
     else
@@ -100,7 +99,6 @@ function _wrapinterface(I, s, b::InterfaceBoundary{Val{true}(), Val{false}()}, j
         discu2 = s.discvars[depvar(u2, s)]
         N = ndims(u, s)
         I1 = unitindex(N, j)
-        # update index
         I = I + (1 - l1) * I1
         return RefCartesianIndex(I, discu2)
     else
@@ -110,4 +108,46 @@ end
 
 function _wrapinterface(I, s, b::InterfaceBoundary{B, B}, j) where {B}
     throw(ArgumentError("Interface $(b.eq) joins two variables at the same end of the domain, this is not supported. Please post an issue if you need this feature."))
+end
+
+"""
+    bcoord(I, bs, s, jx)
+
+Physical coordinate of raw tap index `I` in the differentiated grid's chart. Wrapped taps
+use the exact interface chart transition: periodic shift = period length, contiguous
+shift = 0. Result is strictly increasing across the seam.
+"""
+function bcoord(I, bs, s, jx)
+    j, x = jx
+    for b in bs
+        c = _wrapcoord(I, s, b, j)
+        c === nothing || return c
+    end
+    return s.grid[x][I[j]]
+end
+
+_wrapcoord(I, s, b::AbstractBoundary, j) = nothing
+
+function _wrapcoord(I, s, b::InterfaceBoundary{Val{false}(), Val{true}()}, j)
+    if I[j] <= 1
+        grid1 = s.grid[b.x]
+        grid2 = s.grid[b.x2]
+        i2 = I[j] + length(grid2) - 1
+        # grid2 upper edge ≡ grid1 lower edge
+        return grid2[i2] - (grid2[end] - grid1[1])
+    else
+        return nothing
+    end
+end
+
+function _wrapcoord(I, s, b::InterfaceBoundary{Val{true}(), Val{false}()}, j)
+    grid1 = s.grid[b.x]
+    if I[j] > length(grid1)
+        grid2 = s.grid[b.x2]
+        i2 = I[j] + 1 - length(grid1)
+        # grid2 lower edge ≡ grid1 upper edge
+        return grid2[i2] + (grid1[end] - grid2[1])
+    else
+        return nothing
+    end
 end

--- a/src/discretization/schemes/function_scheme/function_scheme.jl
+++ b/src/discretization/schemes/function_scheme/function_scheme.jl
@@ -1,8 +1,6 @@
-function get_f_and_taps(F::FunctionalScheme, II, s, bs, jx, u)
+function get_f_taps_coords(F::FunctionalScheme, II, s, bs, jx, u)
     j, x = jx
-    # unit index in direction of the derivative
     I1 = unitindex(ndims(u, s), j)
-    # offset is important due to boundary proximity
     haslower, hasupper = haslowerupper(bs, x)
 
     lower_point_count = length(F.lower)
@@ -11,16 +9,32 @@ function get_f_and_taps(F::FunctionalScheme, II, s, bs, jx, u)
     if (II[j] <= lower_point_count) & !haslower
         f = F.lower[II[j]]
         offset = 1 - II[j]
-        Itap = [II + (i + offset) * I1 for i in 0:(F.boundary_points - 1)]
+        Iraw = [II + (i + offset) * I1 for i in 0:(F.boundary_points - 1)]
+        Itap = Iraw
     elseif (II[j] > (length(s, x) - upper_point_count)) & !hasupper
         f = F.upper[length(s, x) - II[j] + 1]
         offset = length(s, x) - II[j]
-        Itap = [II + (i + offset) * I1 for i in (-F.boundary_points + 1):1:0]
+        Iraw = [II + (i + offset) * I1 for i in (-F.boundary_points + 1):1:0]
+        Itap = Iraw
     else
+        # Single-wrap invariant: periodic u[1] ≡ u[N] leaves N-1 distinct nodes, so
+        # N-1 >= interior_points. Deliberately conservative for one-sided interfaces.
+        if (haslower || hasupper) && (length(s, x) - 1 < F.interior_points)
+            error(
+                "Scheme $(F.name) requires at least $(F.interior_points + 1) grid points in $x to wrap its stencil across an interface or periodic boundary; got $(length(s, x))."
+            )
+        end
         f = F.interior
-        Itap = [bwrap(II + i * I1, bs, s, jx) for i in half_range(F.interior_points)]
+        # Iraw: unwrapped, feeds bcoord; Itap: wrapped, feeds u lookup.
+        Iraw = [II + i * I1 for i in half_range(F.interior_points)]
+        Itap = [bwrap(I, bs, s, jx) for I in Iraw]
     end
 
+    return f, Itap, Iraw
+end
+
+function get_f_and_taps(F::FunctionalScheme, II, s, bs, jx, u)
+    f, Itap, _ = get_f_taps_coords(F, II, s, bs, jx, u)
     return f, Itap
 end
 
@@ -28,23 +42,34 @@ function function_scheme(F::FunctionalScheme, II, s, bs, jx, u, ufunc)
     j, x = jx
     ndims(u, s) == 0 && return 0
 
-    f, Itap = get_f_and_taps(F, II, s, bs, jx, u)
+    f, Itap, Iraw = get_f_taps_coords(F, II, s, bs, jx, u)
     if isnothing(f)
         error("Scheme $(F.name) applied to $u in direction of $x at point $II is not defined.")
     end
-    # Tap points of the stencil, this uses boundary_point_count as this is equal to half the stencil size, which is what we want.
     u_disc = ufunc(u, Itap, x)
     ps = vcat(F.ps, params(s))
     t = Num(s.time)
-    itap = map(I -> I[j], Itap)
-    discx = @view s.grid[x][itap]
     dx = s.dxs[x]
-    if F.is_nonuniform
-        if dx isa AbstractVector
-            dx = @views dx[itap[1:(end - 1)]]
+    if isempty(bs)
+        itap = map(I -> I[j], Itap)
+        discx = @view s.grid[x][itap]
+        if F.is_nonuniform
+            if dx isa AbstractVector
+                dx = @views dx[itap[1:(end - 1)]]
+            end
+        elseif dx isa AbstractVector
+            error("Scheme $(F.name) not implemented for nonuniform dxs.")
         end
-    elseif dx isa AbstractVector
-        error("Scheme $(F.name) not implemented for nonuniform dxs.")
+    else
+        # Wrapped taps: grid[x][itap] is non-monotonic; bcoord gives chart-transition coords.
+        discx = [bcoord(I, bs, s, jx) for I in Iraw]
+        if F.is_nonuniform
+            if dx isa AbstractVector
+                dx = diff(discx)
+            end
+        elseif dx isa AbstractVector
+            error("Scheme $(F.name) not implemented for nonuniform dxs.")
+        end
     end
 
     return f(u_disc, ps, t, discx, dx)

--- a/src/system_parsing/interior_map.jl
+++ b/src/system_parsing/interior_map.jl
@@ -27,11 +27,35 @@ PDEBase.get_eqvar(im::InteriorMap, pde) = im.var[pde]
 # then we assign v to it because u is already assigned somewhere else.
 # and use the interior based on the assignment
 
+# Mismatched-grid interfaces are only coordinate-aware on the first-order (advection)
+# path via bcoord; centered/half-offset paths are not. Reject orders > 1 up front.
+function validate_interface_orders(pdes, boundarymap, discretization)
+    for b in filter_interfaces(flatten_vardict(boundarymap))
+        mismatched_interface_dxs(b, discretization) || continue
+        orders = union(d_orders(b.x, pdes), d_orders(b.x2, pdes))
+        higher = filter(>(1), orders)
+        if !isempty(higher)
+            throw(
+                ArgumentError(
+                    "Interface $(b.eq) connects $(b.x) and $(b.x2) with mismatched nonuniform grids, " *
+                        "but the system contains spatial derivative orders $(sort(higher)) in these variables. " *
+                        "Only first-order (advection) derivatives are supported across mismatched grids: " *
+                        "higher-order stencils are not coordinate-aware at the interface and would be " *
+                        "silently inaccurate. Use identical step sizes for the connected variables, or " *
+                        "post an issue on GitHub if you need this feature."
+                )
+            )
+        end
+    end
+    return
+end
+
 function PDEBase.construct_var_equation_mapping(
         pdes::Vector{Equation}, boundarymap, s::DiscreteSpace{N, M},
         discretization::MOLFiniteDifference
     ) where {N, M}
     @assert length(pdes) == M "There must be the same number of equations and unknowns, got $(length(pdes)) equations and $(M) unknowns"
+    validate_interface_orders(pdes, boundarymap, discretization)
     m = buildmatrix(pdes, s)
     varmap = Dict(build_variable_mapping(m, s.ū, pdes))
 

--- a/test/Components/weno_interface_coords.jl
+++ b/test/Components/weno_interface_coords.jl
@@ -1,0 +1,174 @@
+# bcoord chart transitions for wrapped functional-scheme stencils.
+
+using Test
+using ModelingToolkit, MethodOfLines, DomainSets
+using ModelingToolkit: operation
+
+const M = MethodOfLines
+
+function build_discrete_system(pdesys, disc)
+    v = M.VariableMap(pdesys, disc)
+    bcorders = Dict(
+        map(xx -> xx => M.d_orders(xx, M.get_bcs(pdesys)), M.PDEBase.all_ivs(v))
+    )
+    bmap = M.PDEBase.parse_bcs(M.get_bcs(pdesys), v, bcorders)
+    s = M.construct_discrete_space(v, disc)
+    eqs = M.get_eqs(pdesys)
+    eqs = eqs isa AbstractVector ? Vector{Equation}(eqs) : Equation[eqs]
+    im = M.PDEBase.construct_var_equation_mapping(eqs, bmap, s, disc)
+    return im, s, bmap
+end
+
+function perturbed_grid(a, b, n; amp = 0.004, seedmul = 1.0)
+    g = collect(range(a, b, length = n))
+    g[2:(end - 1)] .+= amp .* sin.(seedmul .* (1:(n - 2)))
+    @assert all(diff(g) .> 0)
+    return g
+end
+
+@testset "Periodic chart transition (bcoord)" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+
+    g = perturbed_grid(0.0, 2.0, 21)
+    N = length(g)
+    L = g[end] - g[1]
+
+    eq = Dt(u(t, x)) ~ -Dx(u(t, x))
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0.0) ~ u(t, 2.0)]
+    domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 2.0)]
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+    disc = MOLFiniteDifference([x => g], t; advection_scheme = WENOScheme())
+    im, s, bmap = build_discrete_system(pdesys, disc)
+
+    pde = first(keys(im.I))
+    u_field = im.var[pde]
+    j = M.x2i(s, u_field, x)
+    bs = M.PDEBase.filter_interfaces(bmap[only(keys(bmap))][x])
+    jx = (j, x)
+
+    haslower, hasupper = M.PDEBase.haslowerupper(bs, x)
+    @test haslower && hasupper
+
+    for i in 2:(N - 1)
+        @test M.bcoord(CartesianIndex(i), bs, s, jx) == g[i]
+    end
+
+    # Lower wrap: period shift -L; u[1] ~ u[N].
+    @test M.bcoord(CartesianIndex(1), bs, s, jx) ≈ g[N] - L
+    @test M.bcoord(CartesianIndex(1), bs, s, jx) ≈ g[1]
+    @test M.bcoord(CartesianIndex(0), bs, s, jx) ≈ g[N - 1] - L
+    @test M.bcoord(CartesianIndex(-1), bs, s, jx) ≈ g[N - 2] - L
+
+    # Upper wrap: period shift +L.
+    @test M.bcoord(CartesianIndex(N + 1), bs, s, jx) ≈ g[2] + L
+
+    # Monotonic coords at seam-adjacent points.
+    for II in (CartesianIndex(2), CartesianIndex(3), CartesianIndex(N - 1), CartesianIndex(N))
+        coords = [M.bcoord(II + CartesianIndex(i), bs, s, jx) for i in -2:2]
+        @test all(diff(coords) .> 0)
+    end
+
+    F = WENOScheme()
+    for II in (CartesianIndex(2), CartesianIndex(N))
+        f, Itap, Iraw = M.get_f_taps_coords(F, II, s, bs, jx, u_field)
+        @test f === F.interior
+        discx = [M.bcoord(I, bs, s, jx) for I in Iraw]
+        @test all(diff(discx) .> 0)
+    end
+end
+
+@testset "Periodic stencil-wrap guard (N-1 >= interior_points)" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+
+    function guard_setup(n)
+        g = perturbed_grid(0.0, 2.0, n; amp = 0.002)
+        eq = Dt(u(t, x)) ~ -Dx(u(t, x))
+        bcs = [u(0, x) ~ sinpi(x), u(t, 0.0) ~ u(t, 2.0)]
+        domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 2.0)]
+        @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+        disc = MOLFiniteDifference([x => g], t; advection_scheme = WENOScheme())
+        im, s, bmap = build_discrete_system(pdesys, disc)
+        u_field = im.var[first(keys(im.I))]
+        j = M.x2i(s, u_field, x)
+        bs = M.PDEBase.filter_interfaces(bmap[only(keys(bmap))][x])
+        return s, bs, (j, x), u_field
+    end
+
+    F = WENOScheme()
+
+    # N = 5: only 4 distinct physical nodes (u[1] ~ u[N]); wrap must be rejected.
+    s5, bs5, jx5, u5 = guard_setup(5)
+    @test_throws "requires at least" M.get_f_taps_coords(F, CartesianIndex(3), s5, bs5, jx5, u5)
+
+    # N = 6: minimal admissible periodic grid; interior path must engage cleanly.
+    s6, bs6, jx6, u6 = guard_setup(6)
+    f6, _, Iraw6 = M.get_f_taps_coords(F, CartesianIndex(3), s6, bs6, jx6, u6)
+    @test f6 === F.interior
+    discx6 = [M.bcoord(I, bs6, s6, jx6) for I in Iraw6]
+    @test all(diff(discx6) .> 0)
+end
+
+@testset "Contiguous two-domain chart transition (bcoord)" begin
+    @parameters t x1 x2
+    @variables u1(..) u2(..)
+    Dt = Differential(t)
+    Dx1 = Differential(x1)
+    Dx2 = Differential(x2)
+
+    g1 = perturbed_grid(0.0, 0.5, 11; amp = 0.002)
+    g2 = perturbed_grid(0.5, 1.0, 16; amp = 0.002, seedmul = 2.0)
+    N1 = length(g1)
+
+    eqs = [
+        Dt(u1(t, x1)) ~ -Dx1(u1(t, x1)),
+        Dt(u2(t, x2)) ~ -Dx2(u2(t, x2)),
+    ]
+    bcs = [
+        u1(0, x1) ~ sinpi(2x1),
+        u2(0, x2) ~ sinpi(2x2),
+        u1(t, 0.0) ~ sinpi(-2t),
+        u1(t, 0.5) ~ u2(t, 0.5),
+        Dx2(u2(t, 1.0)) ~ 0.0,
+    ]
+    domains = [
+        t ∈ Interval(0.0, 0.2),
+        x1 ∈ Interval(0.0, 0.5),
+        x2 ∈ Interval(0.5, 1.0),
+    ]
+    @named pdesys = PDESystem(
+        eqs, bcs, domains, [t, x1, x2], [u1(t, x1), u2(t, x2)]
+    )
+
+    disc = MOLFiniteDifference(
+        [x1 => g1, x2 => g2], t; advection_scheme = WENOScheme()
+    )
+    im, s, bmap = build_discrete_system(pdesys, disc)
+
+    # u1 upper wrap: coords from g2, zero shift.
+    bs1 = M.PDEBase.filter_interfaces(bmap[operation(M.unwrap(u1(t, x1)))][x1])
+    @test !isempty(bs1)
+    j1 = M.x2i(s, M.depvar(M.unwrap(u1(t, x1)), s), x1)
+    @test M.bcoord(CartesianIndex(N1), bs1, s, (j1, x1)) == g1[N1]
+    @test M.bcoord(CartesianIndex(N1 + 1), bs1, s, (j1, x1)) ≈ g2[2]
+    @test M.bcoord(CartesianIndex(N1 + 2), bs1, s, (j1, x1)) ≈ g2[3]
+    coords1 = [M.bcoord(CartesianIndex(N1 + i), bs1, s, (j1, x1)) for i in -2:2]
+    @test all(diff(coords1) .> 0)
+
+    # u2 lower wrap: coords from g1, zero shift.
+    bs2 = M.PDEBase.filter_interfaces(bmap[operation(M.unwrap(u2(t, x2)))][x2])
+    @test !isempty(bs2)
+    j2 = M.x2i(s, M.depvar(M.unwrap(u2(t, x2)), s), x2)
+    @test M.bcoord(CartesianIndex(2), bs2, s, (j2, x2)) == g2[2]
+    @test M.bcoord(CartesianIndex(1), bs2, s, (j2, x2)) ≈ g1[N1]
+    @test M.bcoord(CartesianIndex(0), bs2, s, (j2, x2)) ≈ g1[N1 - 1]
+    @test M.bcoord(CartesianIndex(-1), bs2, s, (j2, x2)) ≈ g1[N1 - 2]
+    coords2 = [M.bcoord(CartesianIndex(2 + i), bs2, s, (j2, x2)) for i in -2:2]
+    @test all(diff(coords2) .> 0)
+end

--- a/test/Convection_WENO/MOL_1D_WENO_NU_Interface.jl
+++ b/test/Convection_WENO/MOL_1D_WENO_NU_Interface.jl
@@ -1,0 +1,152 @@
+# NU WENO: periodic and two-domain interface BCs.
+
+using ModelingToolkit, MethodOfLines, DomainSets, LinearAlgebra, Test
+using OrdinaryDiffEq
+using SciMLBase
+
+# Self-similar stretching: refinement isolates asymptotic MMS order.
+stretched_grid(a, b, n; amp = 0.15) = [
+    let ξ = a + (b - a) * (i - 1) / (n - 1)
+            ξ + amp * sinpi(2 * (ξ - a) / (b - a))
+    end
+        for i in 1:n
+]
+
+@testset "Periodic non-uniform WENO: traveling wave accuracy" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+
+    T_END = 0.5
+    u_exact(x, t) = sinpi(x - t)
+
+    eq = Dt(u(t, x)) ~ -Dx(u(t, x))
+    bcs = [
+        u(0, x) ~ sinpi(x),
+        u(t, 0.0) ~ u(t, 2.0),
+    ]
+    domains = [t ∈ Interval(0.0, T_END), x ∈ Interval(0.0, 2.0)]
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+    errs = map((41, 81, 161)) do n
+        g = stretched_grid(0.0, 2.0, n; amp = 0.05)
+        @assert all(diff(g) .> 0)
+        disc = MOLFiniteDifference([x => g], t; advection_scheme = WENOScheme())
+        prob = discretize(pdesys, disc)
+        sol = solve(prob, Tsit5(); abstol = 1.0e-10, reltol = 1.0e-10, saveat = [T_END])
+        @test SciMLBase.successful_retcode(sol)
+        usol = sol[u(t, x)][end, :]
+        @test all(isfinite, usol)
+        maximum(abs.(usol .- u_exact.(sol[x], T_END)))
+    end
+
+    @test errs[1] < 5.0e-3
+    orders = [log2(errs[k] / errs[k + 1]) for k in 1:(length(errs) - 1)]
+    # NU WENO-5: formally 4th order in smooth regions.
+    @test all(>(3.0), orders)
+    @test orders[end] > 3.5
+end
+
+@testset "Two-domain interface, non-uniform grids: co-refined EOC" begin
+    @parameters t x1 x2
+    @variables u1(..) u2(..)
+    Dt = Differential(t)
+    Dx1 = Differential(x1)
+    Dx2 = Differential(x2)
+
+    T_END = 0.5
+    pulse(x, t) = exp(-((x - t) - 0.7)^2 / (2 * 0.1^2))
+
+    eqs = [
+        Dt(u1(t, x1)) ~ -Dx1(u1(t, x1)),
+        Dt(u2(t, x2)) ~ -Dx2(u2(t, x2)),
+    ]
+    bcs = [
+        u1(0, x1) ~ pulse(x1, 0.0),
+        u2(0, x2) ~ pulse(x2, 0.0),
+        u1(t, 0.0) ~ pulse(0.0, t),
+        u1(t, 1.0) ~ u2(t, 1.0),
+        Dx2(u2(t, 2.0)) ~ 0.0,
+    ]
+    domains = [
+        t ∈ Interval(0.0, T_END),
+        x1 ∈ Interval(0.0, 1.0),
+        x2 ∈ Interval(1.0, 2.0),
+    ]
+    @named pdesys = PDESystem(
+        eqs, bcs, domains, [t, x1, x2], [u1(t, x1), u2(t, x2)]
+    )
+
+    # Co-refinement: interval counts double each level, mismatch ratio preserved,
+    # so the seam crossing is exercised at every resolution.
+    levels = ((41, 61), (81, 121), (161, 241))
+    errs = map(levels) do (n1, n2)
+        # Deliberately mismatched NU grids across the interface.
+        g1 = stretched_grid(0.0, 1.0, n1; amp = 0.03)
+        g2 = stretched_grid(1.0, 2.0, n2; amp = 0.04)
+        @assert all(diff(g1) .> 0) && all(diff(g2) .> 0)
+
+        disc = MOLFiniteDifference(
+            [x1 => g1, x2 => g2], t; advection_scheme = WENOScheme()
+        )
+        prob = discretize(pdesys, disc)
+        sol = solve(prob, Tsit5(); abstol = 1.0e-10, reltol = 1.0e-10, saveat = [T_END])
+        @test SciMLBase.successful_retcode(sol)
+
+        u1sol = sol[u1(t, x1)][end, :]
+        u2sol = sol[u2(t, x2)][end, :]
+        @test all(isfinite, u1sol) && all(isfinite, u2sol)
+
+        # Seam continuity: interface identification is algebraic.
+        @test abs(u1sol[end] - u2sol[1]) < 1.0e-8
+
+        # Pulse straddles the interface at T_END.
+        e1 = maximum(abs.(u1sol .- pulse.(sol[x1], T_END)))
+        e2 = maximum(abs.(u2sol .- pulse.(sol[x2], T_END)))
+        max(e1, e2)
+    end
+
+    @test errs[2] < 5.0e-3
+    orders = [log2(errs[k] / errs[k + 1]) for k in 1:(length(errs) - 1)]
+    # NU WENO-5: formally 4th order in smooth regions; no order loss across the seam.
+    @test all(>(3.0), orders)
+    @test orders[end] > 3.3
+end
+
+@testset "Mismatched NU interface rejects higher-order derivatives" begin
+    @parameters t x1 x2
+    @variables c1(..) c2(..)
+    Dt = Differential(t)
+    Dx1 = Differential(x1)
+    Dx2 = Differential(x2)
+
+    eqs = [
+        Dt(c1(t, x1)) ~ Dx1(Dx1(c1(t, x1))),
+        Dt(c2(t, x2)) ~ Dx2(Dx2(c2(t, x2))),
+    ]
+    bcs = [
+        c1(0, x1) ~ 1 + cospi(2 * x1),
+        c2(0, x2) ~ 1 + cospi(2 * x2),
+        Dx1(c1(t, 0.0)) ~ 0.0,
+        c1(t, 0.5) ~ c2(t, 0.5),
+        Dx1(c1(t, 0.5)) ~ Dx2(c2(t, 0.5)),
+        Dx2(c2(t, 1.0)) ~ 0.0,
+    ]
+    domains = [
+        t ∈ Interval(0.0, 0.1),
+        x1 ∈ Interval(0.0, 0.5),
+        x2 ∈ Interval(0.5, 1.0),
+    ]
+    @named pdesys = PDESystem(
+        eqs, bcs, domains, [t, x1, x2], [c1(t, x1), c2(t, x2)]
+    )
+
+    g1 = stretched_grid(0.0, 0.5, 21; amp = 0.01)
+    g2 = stretched_grid(0.5, 1.0, 31; amp = 0.012)
+    disc = MOLFiniteDifference(
+        [x1 => g1, x2 => g2], t; advection_scheme = WENOScheme()
+    )
+    # Dxx crossing a mismatched NU interface is not coordinate-aware; must be rejected.
+    @test_throws ArgumentError discretize(pdesys, disc)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,9 @@ run_tests(;
             @safetestset "WENO Boundary Integration" begin
                 include(joinpath(@__DIR__, "Components", "weno_boundary_integration.jl"))
             end
+            @safetestset "WENO Interface Coordinates" begin
+                include(joinpath(@__DIR__, "Components", "weno_interface_coords.jl"))
+            end
             @safetestset "ODEFunction" begin
                 include(joinpath(@__DIR__, "Components", "ODEFunction_test.jl"))
             end
@@ -72,7 +75,14 @@ run_tests(;
         "MOL_Interface2" => joinpath(@__DIR__, "MOL_Interface2", "MOLtest2.jl"),
         "Diffusion" => joinpath(@__DIR__, "Diffusion", "MOL_1D_Linear_Diffusion.jl"),
         "Integrals" => joinpath(@__DIR__, "Integrals", "MOL_1D_Integration.jl"),
-        "Convection_WENO" => joinpath(@__DIR__, "Convection_WENO", "MOL_1D_Linear_Convection_WENO.jl"),
+        "Convection_WENO" => function ()
+            @safetestset "WENO Linear Convection" begin
+                include(joinpath(@__DIR__, "Convection_WENO", "MOL_1D_Linear_Convection_WENO.jl"))
+            end
+            return @safetestset "WENO Non-Uniform Interface/Periodic" begin
+                include(joinpath(@__DIR__, "Convection_WENO", "MOL_1D_WENO_NU_Interface.jl"))
+            end
+        end,
         "Higher_Order" => joinpath(@__DIR__, "Higher_Order", "MOL_1D_HigherOrder.jl"),
         "Stationary" => joinpath(@__DIR__, "Stationary", "MOL_NonlinearProblem.jl"),
         "Mixed_Derivatives" => joinpath(@__DIR__, "Mixed_Derivatives", "MOL_Mixed_Deriv.jl"),


### PR DESCRIPTION
# Interface and periodic boundary support for non-uniform WENO

Adds native interface / periodic BC support to the non-uniform WENO-5 advection scheme. Previously this configuration crashed at discretization time (`BoundsError` from slicing the `N-1`-length `dx` vector with wrapped indices) and would have fed non-monotonic coordinates to the kernel.

## Core changes

- **`interface_boundary.jl`** — new `bcoord`/`_wrapcoord`: returns the physical coordinate of a raw stencil tap in the differentiated grid's chart. Wrapped taps use the exact chart transition of the interface (periodic: shift by period length; contiguous two-domain: zero shift), so coordinates are strictly increasing across the seam. Purely additive; existing `bwrap`/`RefCartesianIndex` index-wrapping is untouched.
- **`function_scheme.jl`** — `get_f_taps_coords` now also returns the unwrapped indices (`Iraw`). With interfaces present, `discx` is built via `bcoord` and `dx = diff(discx)`; without interfaces, the original `@view` fast path is byte-identical. Adds a guard: wrapping requires `N-1 >= interior_points` (periodic `u[1] ≡ u[N]` leaves `N-1` distinct nodes), with a clear error otherwise. `get_f_and_taps` kept as a thin wrapper for API compatibility.
- **`MOL_discretization.jl`** — `check_boundarymap` waives the equal-`dx` requirement only for non-uniform `FunctionalScheme` with grid vectors on both sides of the interface (shared predicate `mismatched_interface_dxs`).
- **`interior_map.jl`** — `validate_interface_orders` (called from `construct_var_equation_mapping`): rejects systems containing spatial derivative orders > 1 in variables connected by a mismatched-grid interface, since only the first-order path is coordinate-aware. Prevents silently inaccurate diffusion stencils at the seam; matched-grid interfaces are unaffected.

The WENO kernels (`nonuniform_weno.jl`, `WENO.jl`) are untouched. All new code runs at discretization time; the generated RHS structure is unchanged.

## Tests

- `test/Components/weno_interface_coords.jl` (new): unit tests for `bcoord` chart transitions (periodic shifts, zero-shift contiguous interface, seam monotonicity) and the stencil-wrap guard (`N=5` throws, `N=6` passes).
- `test/Convection_WENO/MOL_1D_WENO_NU_Interface.jl` (new):
  - Periodic non-uniform traveling wave, MMS refinement 41/81/161: observed orders > 3, last > 3.5.
  - Two-domain interface with deliberately mismatched non-uniform grids, co-refined 41+61 / 81+121 / 161+241: observed orders 3.29, 4.13 (no order loss at the seam); seam continuity exact at every level.
  - `@test_throws ArgumentError` for `Dxx` across a mismatched-grid interface.

## Docs

`advection_schemes.md` / `boundary_conditions.md`: document non-uniform periodic/interface support and the first-order-only restriction for mismatched grids.