### PR TITLE
Bump MethodOfLines to v0.11.18 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "0.11.17"
+version = "0.11.18"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `MethodOfLines` 0.11.17 → 0.11.18 so the unreleased change on master gets registered.

Unreleased since v0.11.17:
- 9b3056cb — fix: drop deprecated IfElse.jl dependency (#599)

## Verification
Detected by comparing the `git-tree-sha1` of the latest registered version in the General registry against the `src` tree on `master`: they differ, so the code above is on master but not in any released version.

**No test suite was run locally for this PR** — it changes only the `version` field in `Project.toml` and adds no code. CI on this PR is the check that matters.

Please ignore until reviewed by @ChrisRackauckas.