### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "0.11.18"
+version = "0.11.19"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `MethodOfLines` | 0.11.18 | 0.11.19 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).