### PR TITLE
fix Runic formatting and remove duplicated test in runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ run_tests(;
             @safetestset "WENO Linear Convection" begin
                 include(joinpath(@__DIR__, "Convection_WENO", "MOL_1D_Linear_Convection_WENO.jl"))
             end
-            @safetestset "WENO Non-Uniform Interface/Periodic" begin
+            return @safetestset "WENO Non-Uniform Interface/Periodic" begin
                 include(joinpath(@__DIR__, "Convection_WENO", "MOL_1D_WENO_NU_Interface.jl"))
             end
         end,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,9 +82,6 @@ run_tests(;
             @safetestset "WENO Pipeline Spatial Convergence (MMS)" begin
                 include(joinpath(@__DIR__, "Convection_WENO", "MOL_1D_WENO_NU_Convergence.jl"))
             end
-            @safetestset "WENO Linear Convection" begin
-                include(joinpath(@__DIR__, "Convection_WENO", "MOL_1D_Linear_Convection_WENO.jl"))
-            end
             return @safetestset "WENO Non-Uniform Interface/Periodic" begin
                 include(joinpath(@__DIR__, "Convection_WENO", "MOL_1D_WENO_NU_Interface.jl"))
             end


### PR DESCRIPTION
This PR fixes a minor Runic formatting issue and removes a duplicated test entry (`MOL_1D_Linear_Convection_WENO.jl`) in `test/runtests.jl` caused by a recent merge, restoring passing CI checks on `master`