### PR TITLE
Import Interval and symbolic_discretize from their owning packages

### DIFF
--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -25,7 +25,7 @@ using PDEBase: unitindices, unitindex, remove, insert, sym_dot, VariableMap, dep
     d_orders, vcat!, update_varmap!, get_ops
 
 # staggered changes
-using PDEBase: Interval
+using DomainSets: Interval
 using PDEBase: error_analysis, add_metadata!
 
 # To Extend
@@ -40,7 +40,7 @@ import PDEBase.construct_differential_discretizer
 import PDEBase.discretize_equation!
 import PDEBase.generate_ic_defaults
 import PDEBase.generate_metadata
-import PDEBase.symbolic_discretize
+import SciMLBase.symbolic_discretize
 
 import PDEBase.get_time
 import PDEBase.get_eqvar


### PR DESCRIPTION
## Problem

PDEBase switched from `using DomainSets` / `using SciMLBase` to `import DomainSets` / `import SciMLBase`, so it no longer re-exports these names. Against current PDEBase master:

```
isdefined(PDEBase, :Interval)             = false
isdefined(PDEBase, :symbolic_discretize)  = false
```

MethodOfLines imports both from PDEBase:

```julia
# src/MethodOfLines.jl
28: using PDEBase: Interval
43: import PDEBase.symbolic_discretize
```

On Julia 1.11+ an unresolvable `using X: name` is only a warning, which is why this still loads and tests pass on `julia 1`. **On the LTS it is a hard error.** Measured against PDEBase master on 1.10.11:

```
using PDEBase: Interval             -> UndefVarError: `Interval` not defined
import PDEBase.symbolic_discretize  -> WARNING: could not import PDEBase.symbolic_discretize
```

So MethodOfLines fails to load outright on the Julia LTS. This is currently masked: while PDEBase was briefly at 0.2.0 the downstream jobs died at resolution before reaching it, and now that it is back to 0.1.31 they resolve and pass on 1.12 without exercising the LTS path.

## Fix

Take each name from the package that owns it and declares it public:

- `Interval` from DomainSets — `parentmodule` is IntervalSets, but DomainSets declares it public rather than merely forwarding it (`Base.ispublic(DomainSets, :Interval) == true`), and DomainSets is already a direct dependency. Using IntervalSets directly would mean adding a dependency for no gain.
- `symbolic_discretize` from SciMLBase — `Base.ispublic(SciMLBase, :symbolic_discretize) == true`. This also matches every call site in this package, which already spells it `SciMLBase.symbolic_discretize` (`MOL_discretization.jl:87`, `:109`, `staggered_discretize.jl:6`). The import exists only to bind the name for the `export` on line 120.

No compat change is needed: PDEBase master is 0.1.31 and `PDEBase = "0.1.29"` already admits it.

## Validation

Julia 1.12.6, against PDEBase master plus SciML/PDEBase.jl#101:

```
MethodOfLines loaded OK
symbolic_discretize owner = SciMLBase
Interval owner = IntervalSets
```

The two `WARNING: Imported binding PDEBase.X was undeclared at import time` messages that previously appeared during precompilation are gone.

Test groups, all passing:

| Group | Result |
|---|---|
| `MOL_Interface1` | tests passed |
| `Sol_Interface` | tests passed |
| `Burgers` | tests passed |

Note `MOL_Interface1` needs SciML/PDEBase.jl#101 to pass for an unrelated reason — an array-variable regression in PDEBase (SciML/PDEBase.jl#100). That is a PDEBase-side issue and not affected by this PR.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117aJvytDT3y2jMi5Ng6Q5m