### PR TITLE
fix(docs): Resolve CI Out-of-Memory issue in sispde tutorial

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
@@ -27,7 +26,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 Combinatorics = "1"
 DiffEqBase = "6, 7"
-DifferentialEquations = "7, 8.0"
 Documenter = "1"
 DomainSets = "0.7, 0.8"
 Interpolations = "0.14, 0.15, 0.16"

--- a/docs/src/tutorials/sispde.md
+++ b/docs/src/tutorials/sispde.md
@@ -27,7 +27,8 @@ where ``\int_{0}^{1} S(x)+I(x)dx = 1``.
 Note here elliptic problem has condition ``\int_{0}^{1} S(x)+I(x)dx = 1``.
 
 ```@example sispde
-using DifferentialEquations, SteadyStateDiffEq, ModelingToolkit, MethodOfLines, DomainSets, Plots
+using OrdinaryDiffEq, OrdinaryDiffEqBDF, SteadyStateDiffEq, ModelingToolkit, MethodOfLines,
+      DomainSets, Plots
 
 # Parameters, variables, and derivatives
 @parameters t x
@@ -86,7 +87,7 @@ prob = discretize(pdesys, discretization);
 
 ```@example sispde
 # Solving SIS reaction diffusion model
-sol = solve(prob, Tsit5(), saveat = 0.2);
+sol = solve(prob, FBDF(), saveat = 0.2);
 
 # Retrieving the results
 discrete_x = sol[x]
@@ -106,7 +107,7 @@ See more solvers in [Steady State Solvers · DifferentialEquations.jl](https://d
 
 ```@example sispde
 steadystateprob = SteadyStateProblem(prob)
-steadystate = solve(steadystateprob, DynamicSS(Tsit5()))
+steadystate = solve(steadystateprob, DynamicSS(FBDF()))
 ```
 
 ### The effect of human mobility on endemic size
@@ -121,7 +122,7 @@ I_vars = filter(s -> contains(string(s), "I("), unknowns(prob.f.sys))
 function episize!(dS_val, dI_val)
     newprob = remake(prob, p = [dS => dS_val, dI => dI_val, brn => 3, ϵ => 0.1])
     steadystateprob = SteadyStateProblem(newprob)
-    steadystate = solve(steadystateprob, DynamicSS(Tsit5()))
+    steadystate = solve(steadystateprob, DynamicSS(FBDF()))
     y = sum(steadystate[v] for v in I_vars) * dx
     return y
 end


### PR DESCRIPTION
This PR fixes the documentation CI OOM failure in `sispde.md` caused by using a non-stiff solver (`Tsit5`) on a stiff semi-discretization. 

The solvers were updated to `FBDF` and `DynamicSS(FBDF())`. Additionally, the `DifferentialEquations` umbrella dependency was replaced with specific solver imports.