### PR TITLE
test(qa): Fix unapproved public reexports failure

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -6,6 +6,8 @@ using JET
 run_qa(
     MethodOfLines;
     explicit_imports = true,
+    # Intentional reexports of the SciMLBase-owned user entry points.
+    reexports_allow = (:discretize, :symbolic_discretize),
     api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; persistent_tasks = (; tmax = 300)),
     # Aqua sub-checks with genuine findings, marked broken pending fixes (issue #574):


### PR DESCRIPTION
This PR fixes the failing QA test regarding unapproved public reexports. It explicitly allows `discretize` and `symbolic_discretize` in `run_qa` using `reexports_allow`, as they are intentional facade APIs. The public API and user workflows remain completely unchanged.