### PR TITLE
Set MethodOfLines version to 0.12.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "0.11.20"
+version = "0.12.0"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| MethodOfLines | 0.11.19 | 0.11.20 | 0.12.0 | minor |

## Verification

- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Broken  Total     Time / Wave_Eq_Staggered |    1       5      6  1m26.3s / Test Summary:        | Pass  Total      Time / Array_Discretization |   92     92  11m58.3s / Testing MethodOfLines tests passed`
- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Broken  Total      Time / QA            |   12       6     18  16m55.2s / Testing MethodOfLines tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- MethodOfLines: `@JuliaRegistrator register`