### PR TITLE
test: fix unused keyword argument

### DIFF
--- a/test/MOL_Interface2/MOLtest2.jl
+++ b/test/MOL_Interface2/MOLtest2.jl
@@ -518,7 +518,7 @@ end
 
     @named sys = PDESystem(eq, bcs, domains, [t, φ], [Tₛ(t, φ)])
 
-    discretization = MOLFiniteDifference([φ => 80], t)
+    discretization = MOLFiniteDifference([φ => 80], t, approx_order = 4)
 
     prob = discretize(sys, discretization) # ERROR HERE
 

--- a/test/MOL_Interface2/MOLtest2.jl
+++ b/test/MOL_Interface2/MOLtest2.jl
@@ -518,7 +518,7 @@ end
 
     @named sys = PDESystem(eq, bcs, domains, [t, φ], [Tₛ(t, φ)])
 
-    discretization = MOLFiniteDifference([φ => 80], t, order = 4)
+    discretization = MOLFiniteDifference([φ => 80], t)
 
     prob = discretize(sys, discretization) # ERROR HERE
 


### PR DESCRIPTION
The keyword argument gets forwarded to the problem constructor.