### PR TITLE
qa: use standard rendered API documentation checks

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -8,7 +8,6 @@ run_qa(
     explicit_imports = true,
     # Intentional reexports of the SciMLBase-owned user entry points.
     reexports_allow = (:discretize, :symbolic_discretize),
-    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; persistent_tasks = (; tmax = 300)),
     # Aqua sub-checks with genuine findings, marked broken pending fixes (issue #574):
     #   :ambiguities       — 48 method ambiguities involving MethodOfLines methods


### PR DESCRIPTION
## What changed

Remove the repository-specific `api_docs_kwargs = (; rendered = true)` override. SciMLTesting now enables the rendered public-API documentation check by default, so MethodOfLines can use the standard QA configuration.

No source behavior, public API, or documentation content changes are included.

## Verification

- `git diff --check` passed.
- Runic check for `test/qa/qa.jl` passed.
- `typos test/qa/qa.jl` passed.
- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` passed: `QA | 12 pass, 6 broken, 18 total`; the broken checks are the existing issue-tracked QA exceptions.\n\nPlease ignore this PR until reviewed by @ChrisRackauckas.