### PR TITLE
qa: use SciMLTesting documentation defaults

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -8,7 +8,6 @@ run_qa(
     explicit_imports = true,
     # Intentional reexports of the SciMLBase-owned user entry points.
     reexports_allow = (:discretize, :symbolic_discretize),
-    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; persistent_tasks = (; tmax = 300)),
     # Aqua sub-checks with genuine findings, marked broken pending fixes (issue #574):
     #   :ambiguities       — 48 method ambiguities involving MethodOfLines methods


### PR DESCRIPTION
## Summary

Remove the repository-specific `api_docs_kwargs = (; rendered = true)` override from MethodOfLines QA. The current `master` already declares `SciMLTesting = "2.8"`; this focused PR preserves that floor and does not alter unrelated compatibility bounds.

## Verification

- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed (`12` checks passed, `6` pre-existing broken checks).\n- Runic with docstrings, `typos`, and `git diff --check`: passed.\n\nPlease ignore this draft until reviewed by @ChrisRackauckas.