### PR TITLE
docs: enforce strict documentation checks

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,9 +12,8 @@ include("pages.jl")
 makedocs(
     sitename = "MethodOfLines.jl",
     authors = "Chris Rackauckas, Alex Jones et al.",
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, linkcheck = true,
     modules = [MethodOfLines],
-    warnonly = [:docs_block, :missing_docs, :cross_references],
     linkcheck_ignore = [
         # StackExchange returns 403 for automated requests
         "https://math.stackexchange.com/questions/4333513/nonuniform-finite-difference-grid-for-a-pde-where-the-x-points-depends-on-y-coor",

--- a/docs/src/MOLFiniteDifference.md
+++ b/docs/src/MOLFiniteDifference.md
@@ -1,4 +1,4 @@
-# [Discretization] (@id molfd)
+# [Discretization](@id molfd)
 ```julia
 struct MOLFiniteDifference{G} <: DiffEqBase.AbstractDiscretization
     dxs
@@ -50,4 +50,3 @@ Currently supported options are `grid_align`: `center_align` and `edge_align`. E
 `discretization_strategy`: How the discretized equations are represented symbolically. `ScalarizedDiscretization()` (the default) generates one scalar equation per interior grid point. `ArrayDiscretization()` generates the interior of each PDE as a single symbolic array equation over slices of the discretized variables, e.g. `D(u[2:n-1]) - (u[1:n-2] .- 2u[2:n-1] .+ u[3:n]) ./ dx^2 ~ 0`, which scales much better to large systems during symbolic processing. Patterns without a slice representation (WENO advection, nonlinear/spherical Laplacians, integrals, mixed derivatives, periodic/interface BCs, staggered grids) automatically fall back to pointwise scalar equations for the affected equation, so results are identical to `ScalarizedDiscretization` in all cases.
 
 Any unrecognized keyword arguments will be passed to the `ODEProblem` constructor, see [its documentation](https://docs.sciml.ai/ModelingToolkit/stable/API/problems/#Dynamical-systems) for available options.
-

--- a/docs/src/advection_schemes.md
+++ b/docs/src/advection_schemes.md
@@ -36,8 +36,4 @@ Specified on pages 8-9 of [this document](https://repository.library.brown.edu/s
 
 ## FunctionalScheme
 
-`WENOScheme` is itself implemented as a `FunctionalScheme`, a general mechanism for supplying your own advection scheme as a set of Julia functions. See the docstring below, and [the developer notes](devnotes.md) for how schemes are wired into the discretization.
-
-```@docs
-FunctionalScheme
-```
+`WENOScheme` is itself implemented as a `FunctionalScheme`, a general mechanism for supplying your own advection scheme as a set of Julia functions. See the [`FunctionalScheme`](@ref) API reference and [the developer notes](devnotes.md) for how schemes are wired into the discretization.

--- a/docs/src/api/discretization.md
+++ b/docs/src/api/discretization.md
@@ -4,11 +4,18 @@ CurrentModule = MethodOfLines
 
 # Discretization
 
-```@docs
-MOLFiniteDifference
-DiscreteSpace
+## Public API
+
+```@autodocs
+Modules = [MethodOfLines]
+Private = false
+Order = [:constant, :type, :function]
 ```
 
-```@autodocs; canonical=false
+## Developer API
+
+```@autodocs
 Modules = [MethodOfLines]
+Public = false
+Order = [:constant, :type, :function]
 ```

--- a/docs/src/api/discretization.md
+++ b/docs/src/api/discretization.md
@@ -8,6 +8,7 @@ CurrentModule = MethodOfLines
 
 ```@autodocs
 Modules = [MethodOfLines]
+Public = true
 Private = false
 Order = [:constant, :type, :function]
 ```
@@ -17,5 +18,6 @@ Order = [:constant, :type, :function]
 ```@autodocs
 Modules = [MethodOfLines]
 Public = false
+Private = true
 Order = [:constant, :type, :function]
 ```

--- a/docs/src/api/utils.md
+++ b/docs/src/api/utils.md
@@ -4,8 +4,6 @@ CurrentModule = MethodOfLines
 
 # Utilities
 
-```@docs
-unitindex
-ivs
-Idx
-```
+The utility functions used by the discretization interfaces are documented in the
+[public API](discretization.md#public-api) and [developer API](discretization.md#developer-api)
+reference sections.

--- a/docs/src/boundary_conditions.md
+++ b/docs/src/boundary_conditions.md
@@ -1,4 +1,4 @@
-# [Boundary Conditions] (@id bcs)
+# [Boundary Conditions](@id bcs)
 
 What follows is a set of allowable boundary conditions, please note that this is not exhaustive - try your condition and see if it works, the handling is quite general. If it doesn't, please post an issue and we'll try to support it. Currently, boundary conditions have to be supplied at the edge of the domain, but there are plans to support conditions embedded in the domain.
 

--- a/docs/src/generated/bruss_code.md
+++ b/docs/src/generated/bruss_code.md
@@ -1,5 +1,5 @@
 
-# [Generated Code for the Brusselator Equation] (@id brusscode)
+# [Generated Code for the Brusselator Equation](@id brusscode)
 
 Here's the generated Julia code for the [Brusselator](@ref brusselator), with `dx = dy = 1/4`.
 

--- a/docs/src/generated/bruss_ode_eqs.md
+++ b/docs/src/generated/bruss_ode_eqs.md
@@ -1,4 +1,4 @@
-# [Generated ODE system for the Brusselator Equation] (@id brusssys)
+# [Generated ODE system for the Brusselator Equation](@id brusssys)
 
 Here's the generated system of equations for the [Brusselator](@ref brusselator), with `dx = dy = 1/4`.
 

--- a/docs/src/howitworks.md
+++ b/docs/src/howitworks.md
@@ -1,4 +1,4 @@
-# [How it works] (@id hiw)
+# [How it works](@id hiw)
 
 MethodOfLines.jl makes heavy use of `Symbolics.jl` and `SymbolicUtils.jl`, namely it's rule matching features to recognize terms which require particular discretizations.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# [MethodOfLines.jl: Automated Finite Difference for Physics-Informed Learning] (@id index)
+# [MethodOfLines.jl: Automated Finite Difference for Physics-Informed Learning](@id index)
 
 [MethodOfLines.jl](https://github.com/SciML/MethodOfLines.jl)
 is a Julia package for automated finite difference discretization
@@ -68,7 +68,7 @@ Pkg.add("MethodOfLines")
       + On the [Julia Discourse forums](https://discourse.julialang.org)
       + See also [SciML Community page](https://sciml.ai/community/)
 
-## [Known Limitations] (@id limitations)
+## [Known Limitations](@id limitations)
 
 Currently, the package can discretize almost any system, with some assumptions listed below
 

--- a/docs/src/tutorials/brusselator.md
+++ b/docs/src/tutorials/brusselator.md
@@ -1,4 +1,4 @@
-# [Getting Started] (@id brusselator)
+# [Getting Started](@id brusselator)
 
 ## Using the Brusselator PDE as an example
 

--- a/src/interface/MOLFiniteDifference.jl
+++ b/src/interface/MOLFiniteDifference.jl
@@ -17,7 +17,8 @@ A discretization algorithm.
 
 - `approx_order`: The order of the derivative approximation.
 - `advection_scheme`: The scheme to be used to discretize advection terms, i.e. first order spatial derivatives and associated coefficients. Defaults to `UpwindScheme()`. WENOScheme() is also available, and is more stable and accurate at the cost of complexity.
-- `grid_align`: The grid alignment types. See [`CenterAlignedGrid`](@ref) and [`EdgeAlignedGrid`](@ref).
+- `grid_align`: The grid alignment value. Use [`center_align`](@ref), [`edge_align`](@ref), or
+  `StaggeredGrid()` as appropriate for the discretization.
 - `use_ODAE`: If `true`, the discretization will use the `ODAEproblem` constructor.
     Defaults to `false`.
 - `discretization_strategy`: How the discretized equations are represented symbolically.
@@ -26,6 +27,33 @@ A discretization algorithm.
     symbolic array equation over slices of the discretized variables, falling back to
     pointwise scalar equations for patterns with no slice representation.
 - `kwargs`: Any other keyword arguments you want to pass to the `ODEProblem`.
+
+## Fields
+
+- `dxs`: A dictionary mapping each discretized independent variable to an integer
+  grid size, a spacing, or an explicit grid.
+- `time`: The independent variable left undiscretized, or `nothing` for a fully
+  discretized system.
+- `approx_order`: The requested finite-difference approximation order.
+- `advection_scheme`: The scheme used for first-order spatial derivatives.
+- `grid_align`: The grid alignment marker.
+- `should_transform`: Whether supported symbolic transformations are applied before
+  discretization.
+- `use_ODAE`: Whether the resulting problem may use an `ODAEProblem` formulation.
+- `disc_strategy`: The symbolic equation representation strategy.
+- `useIR`: Whether ModelingToolkit's intermediate representation is used.
+- `callbacks`: Symbolic discretization callbacks.
+- `kwargs`: Additional keyword arguments forwarded to the generated problem.
+
+## Example
+
+```julia
+using ModelingToolkit
+using MethodOfLines
+
+@parameters t x
+discretization = MOLFiniteDifference([x => 0.1], t)
+```
 
 """
 struct MOLFiniteDifference{G, D} <: AbstractEquationSystemDiscretization

--- a/src/interface/MOLFiniteDifference.jl
+++ b/src/interface/MOLFiniteDifference.jl
@@ -5,20 +5,23 @@
 
 A discretization algorithm.
 
-## Arguments
+# Arguments
 
-- `dxs`: A vector of pairs of parameters to the grid step in this dimension, i.e. `[x=>0.2, y=>0.1]`.
-    For a non-uniform rectilinear grid, replace any or all of the step sizes with the grid you'd like to
-    use with that variable, must be an `AbstractVector` but not a `StepRangeLen`.
-- `time`: Your choice of continuous variable, usually time. If `time = nothing`, then discretization
-    yields a `NonlinearProblem`. Defaults to `nothing`.
+- `dxs`: A vector of pairs of parameters to the grid step in this dimension, i.e.
+  `[x => 0.2, y => 0.1]`. For a non-uniform rectilinear grid, replace any or all of the
+  step sizes with the grid to use with that variable. It must be an `AbstractVector`,
+  but not a `StepRangeLen`.
+- `time`: The continuous variable, usually time. If `time = nothing`, discretization
+  yields a `NonlinearProblem`. Defaults to `nothing`.
 
-## Keyword Arguments
+# Keywords
 
 - `approx_order`: The order of the derivative approximation.
-- `advection_scheme`: The scheme to be used to discretize advection terms, i.e. first order spatial derivatives and associated coefficients. Defaults to `UpwindScheme()`. WENOScheme() is also available, and is more stable and accurate at the cost of complexity.
-- `grid_align`: The grid alignment value. Use [`center_align`](@ref), [`edge_align`](@ref), or
-  `StaggeredGrid()` as appropriate for the discretization.
+- `advection_scheme`: The scheme used to discretize first-order spatial derivatives
+  and associated coefficients. Defaults to `UpwindScheme()`. `WENOScheme()` is more
+  stable and accurate at the cost of complexity.
+- `grid_align`: The grid alignment value. Use [`center_align`](@ref),
+  [`edge_align`](@ref), or `StaggeredGrid()` as appropriate for the discretization.
 - `use_ODAE`: If `true`, the discretization will use the `ODAEproblem` constructor.
     Defaults to `false`.
 - `discretization_strategy`: How the discretized equations are represented symbolically.
@@ -26,9 +29,9 @@ A discretization algorithm.
     grid point. `ArrayDiscretization()` generates the interior of each PDE as a single
     symbolic array equation over slices of the discretized variables, falling back to
     pointwise scalar equations for patterns with no slice representation.
-- `kwargs`: Any other keyword arguments you want to pass to the `ODEProblem`.
+- `kwargs`: Additional keyword arguments passed to the `ODEProblem`.
 
-## Fields
+# Fields
 
 - `dxs`: A dictionary mapping each discretized independent variable to an integer
   grid size, a spacing, or an explicit grid.
@@ -45,7 +48,7 @@ A discretization algorithm.
 - `callbacks`: Symbolic discretization callbacks.
 - `kwargs`: Additional keyword arguments forwarded to the generated problem.
 
-## Example
+# Example
 
 ```julia
 using ModelingToolkit

--- a/src/interface/grid_types.jl
+++ b/src/interface/grid_types.jl
@@ -1,11 +1,40 @@
 abstract type AbstractGrid end
 
+"""
+    CenterAlignedGrid()
+
+Grid alignment strategy that places the first and last grid points on the domain
+boundaries. Use the singleton [`center_align`](@ref) as the `grid_align` value in
+[`MOLFiniteDifference`](@ref).
+
+This is a stateless marker type and has no fields.
+"""
 struct CenterAlignedGrid <: AbstractGrid
 end
 
+"""
+    EdgeAlignedGrid()
+
+Grid alignment strategy that places grid points half a spacing from the domain
+boundaries. Use the singleton [`edge_align`](@ref) as the `grid_align` value in
+[`MOLFiniteDifference`](@ref), for example when edge-centered values improve
+Neumann boundary accuracy.
+
+This is a stateless marker type and has no fields.
+"""
 struct EdgeAlignedGrid <: AbstractGrid
 end
 
+"""
+    StaggeredGrid()
+
+Grid alignment strategy for variables whose grid locations are staggered relative
+to the primary grid. Pass an instance as `grid_align` to
+[`MOLFiniteDifference`](@ref) and specify the corresponding variable alignment
+when constructing the discretization.
+
+This is a stateless marker type and has no fields.
+"""
 struct StaggeredGrid <: AbstractGrid
 end
 


### PR DESCRIPTION
## Summary

- Remove the obsolete `doctest = false` and `warnonly` Documenter settings without adding repository-specific QA overrides or link-check exclusions.
- Split the discretization reference into explicit public (`Public = true`, `Private = false`) and developer (`Public = false`, `Private = true`) API sections.
- Put SciMLStyle docstrings on the `MOLFiniteDifference` and grid-type definitions, remove stale references, and repair documentation headings and links.
- Keep the scope to documentation/API coverage and SciMLTesting's upstream defaults from https://github.com/SciML/MethodOfLines.jl/pull/637. This PR does not change dependencies, imports, runtime behavior, or existing QA checks.

The grid types are stateless discretization markers rather than a standalone generic interface. Existing functional tests already exercise center-, edge-, and staggered-grid selection through `MOLFiniteDifference`, so this PR does not add a package-specific interface-test abstraction.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Runic; exit(Runic.main(["--check", "docs/make.jl", "src/interface/grid_types.jl", "src/interface/MOLFiniteDifference.jl"]))'` exited 0 with no output.
- `typos $(git diff --name-only origin/master)` exited 0 with no output.
- `git diff --check origin/master` exited 0 with no output.
- `GROUP=QA ~/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed on Julia 1.12.7 with SciMLTesting 2.10.0: `QA | 12 6 18 7m31.1s`; `Testing MethodOfLines tests passed`. The six existing tracked broken QA checks remain visible and unchanged.
- `git rebase origin/master` reported `Current branch codex/strict-docs-qa is up to date.` Fresh pre-push divergence was `origin/master...HEAD = 0 2` and `fork/codex/strict-docs-qa...HEAD = 0 1`.
- The docs environment was temporarily developed against this checkout with `~/.juliaup/bin/julia +1.12 --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.status(["MethodOfLines"])'`, then `~/.juliaup/bin/julia +1.12 --startup-file=no --project=docs docs/make.jl` ran strictly. Doctests, executable examples, autodocs, cross-references, and missing-doc checks completed. The build exited 1 only at link checking because GitHub returned HTTP 429 for these links:
  - `https://github.com/SciML/MethodOfLines.jl/blob/master/src/discretization/generate_finite_difference_rules.jl`
  - `https://github.com/SciML/MethodOfLines.jl/blob/master/src/discretization/differential_discretizer.jl`
  - `https://github.com/SciML/MethodOfLines.jl/blob/master/src/MOL_discretization.jl`
  - `https://github.com/SciML/MethodOfLines.jl/blob/949d0fee5e97c4adc59057460b3708161f776e9b/src/discretization/generate_finite_difference_rules.jl#L271`
  - `https://github.com/SciML/ColPrac/blob/master/README.md`

Docs cleanup succeeded (`DOCS_SETUP_EXIT=0`, `DOCS_BUILD_EXIT=1`, `DOCS_CLEANUP_EXIT=0`); no local-path metadata is included. No link was ignored and no failure was downgraded. No full non-QA or downstream suite was run locally.

## CI status

At head `6c0e7b3ff8a1bb561a286f80b9a37d5f18739d6e`, CI completed with 67 passing checks and two failures representing the same out-of-scope Julia 1.10 `2D_Diffusion` error:

- `2D_Diffusion (Julia lts)`: https://github.com/SciML/MethodOfLines.jl/actions/runs/31994511505/job/95283739067
- `Downgrade Tests`: https://github.com/SciML/MethodOfLines.jl/actions/runs/31994511294/job/95283683625

Both fail at `test/2D_Diffusion/MOL_2D_Diffusion.jl:75` with `BoundsError: attempt to access 11-element StepRangeLen ... at index [12]`, originating from `src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl:75`. This docs-only PR does not change that implementation, its tests, or dependency resolution. Documentation, QA, downstream, benchmarks, Runic, typos, and all other matrix jobs passed.
