### PR TITLE
test: call discretize through SciMLBase

### DIFF
--- a/test/2D_Diffusion/MOL_2D_Diffusion.jl
+++ b/test/2D_Diffusion/MOL_2D_Diffusion.jl
@@ -2,6 +2,7 @@
 
 # Packages and inclusions
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+import SciMLBase
 using ModelingToolkit: Differential
 
 # Tests
@@ -54,7 +55,7 @@ using ModelingToolkit: Differential
 
     # Method of lines discretization
     discretization = MOLFiniteDifference([x => dx, y => dy], t; approx_order = order)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
     # Solution of the ODE system
     sol = solve(prob, Tsit5())
     r_space_x = sol[x]
@@ -124,7 +125,7 @@ end
     dx = 0.1
     dy = 0.2
     discretization = MOLFiniteDifference([x => dx, y => dy], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     sol = solve(prob, Rosenbrock23())

--- a/test/MOL_Interface1/MOLtest1.jl
+++ b/test/MOL_Interface1/MOLtest1.jl
@@ -1,4 +1,5 @@
 using ModelingToolkit, MethodOfLines, LinearAlgebra, OrdinaryDiffEq
+import SciMLBase
 using OrdinaryDiffEqRosenbrock: Rodas4
 using OrdinaryDiffEqSDIRK: TRBDF2
 using ModelingToolkit: operation, iscall, arguments
@@ -73,7 +74,7 @@ end
     dx = 0.1
     dy = 0.2
     discretization = MOLFiniteDifference([x => dx, y => dy], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
     sol = solve(prob, Tsit5())
 end
 
@@ -270,7 +271,7 @@ end
 
     # Method of lines discretization
     discretization = MOLFiniteDifference([x => dx], nothing, approx_order = order)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # # Solution of the ODE system
     sol = NonlinearSolve.solve(prob, NewtonRaphson())

--- a/test/Nonlinear_Diffusion/MOL_1D_NonLinear_Diffusion.jl
+++ b/test/Nonlinear_Diffusion/MOL_1D_NonLinear_Diffusion.jl
@@ -47,7 +47,7 @@ using ModelingToolkit: Differential
     # Method of lines discretization
     dx = 0.01
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -103,7 +103,7 @@ end
 #     # Method of lines discretization
 #     dx = 0.01
 #     discretization = MOLFiniteDifference([x=>dx],t)
-#     prob = ModelingToolkit.discretize(pdesys,discretization)
+#     prob = SciMLBase.discretize(pdesys,discretization)
 
 #     # Solution of the ODE system
 #     using OrdinaryDiffEq
@@ -163,7 +163,7 @@ end
     # Method of lines discretization
     dx = 0.01
     discretization = MOLFiniteDifference([x => dx], t, approx_order = 2)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     #disco = MOLFiniteDifference_original([x=>dx],t)
     #prob_orig = discretize_original(pdesys,disco)
@@ -227,7 +227,7 @@ end
     # Method of lines discretization
     dx = 0.01
     discretization = MOLFiniteDifference([x => dx], t, approx_order = 4)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     #disco = MOLFiniteDifference_original([x=>dx],t)
     #prob_orig = discretize_original(pdesys,disco)
@@ -288,7 +288,7 @@ end
 #     # Method of lines discretization
 #     dx = 0.01
 #     discretization = MOLFiniteDifference([x=>dx],t)
-#     prob = ModelingToolkit.discretize(pdesys,discretization)
+#     prob = SciMLBase.discretize(pdesys,discretization)
 
 #     # Solution of the ODE system
 #     using OrdinaryDiffEq
@@ -348,7 +348,7 @@ end
     # Method of lines discretization
     dx = 0.01
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -409,7 +409,7 @@ end
     # Method of lines discretization
     dx = 0.01
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -471,7 +471,7 @@ end
     # Method of lines discretization
     dx = 0.01
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -532,7 +532,7 @@ end
     # Method of lines discretization
     dx = 0.01
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq

--- a/test/Nonlinear_Diffusion_NU/MOL_1D_NonLinear_Diffusion_NonUniform.jl
+++ b/test/Nonlinear_Diffusion_NU/MOL_1D_NonLinear_Diffusion_NonUniform.jl
@@ -53,7 +53,7 @@ using StableRNGs
         rand(StableRNG(0), [0.001, -0.001], length(dx[2:(end - 1)]))
 
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -110,7 +110,7 @@ end
 #     # Method of lines discretization
 #     dx = 0.01
 #     discretization = MOLFiniteDifference([x => dx], t)
-#     prob = ModelingToolkit.discretize(pdesys, discretization)
+#     prob = SciMLBase.discretize(pdesys, discretization)
 
 #     # Solution of the ODE system
 #     using OrdinaryDiffEq
@@ -175,7 +175,7 @@ end
         rand(StableRNG(0), [0.001, -0.001], length(dx[2:(end - 1)]))
 
     discretization = MOLFiniteDifference([x => dx], t, approx_order = 2)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     #disco = MOLFiniteDifference_original([x=>dx],t)
     #prob_orig = discretize_original(pdesys,disco)
@@ -243,7 +243,7 @@ end
         rand(StableRNG(0), [0.001, -0.001], length(dx[2:(end - 1)]))
 
     discretization = MOLFiniteDifference([x => dx], t, approx_order = 4)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     #disco = MOLFiniteDifference_original([x=>dx],t)
     #prob_orig = discretize_original(pdesys,disco)
@@ -303,7 +303,7 @@ end
 #     # Method of lines discretization
 #     dx = 0.01
 #     discretization = MOLFiniteDifference([x => dx], t)
-#     prob = ModelingToolkit.discretize(pdesys, discretization)
+#     prob = SciMLBase.discretize(pdesys, discretization)
 
 #     # Solution of the ODE system
 #     using OrdinaryDiffEq
@@ -367,7 +367,7 @@ end
         rand(StableRNG(0), [0.001, -0.001], length(dx[2:(end - 1)]))
 
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -432,7 +432,7 @@ end
         rand(StableRNG(0), [0.001, -0.001], length(dx[2:(end - 1)]))
 
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -499,7 +499,7 @@ end
         rand(StableRNG(0), [0.001, -0.001], length(dx[2:(end - 1)]))
 
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq
@@ -565,7 +565,7 @@ end
         rand(StableRNG(0), [0.001, -0.001], length(dx[2:(end - 1)]))
 
     discretization = MOLFiniteDifference([x => dx], t)
-    prob = ModelingToolkit.discretize(pdesys, discretization)
+    prob = SciMLBase.discretize(pdesys, discretization)
 
     # Solution of the ODE system
     using OrdinaryDiffEq


### PR DESCRIPTION
## What changed

Qualify downstream discretization calls through `SciMLBase`, the package that owns and exports `discretize`. This keeps the MethodOfLines tests on public dependency API after ModelingToolkit stopped incidentally exposing the imported name in https://github.com/SciML/ModelingToolkit.jl/commit/03c130782349ca8ed91e4f9a92da08d590c53ffe.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

### Failing before the fix

Against a clean ModelingToolkit checkout at `3fe375e19031102e95c7775c4d8a6aac9895767b`:

```sh
JULIA_DEPOT_PATH=../.mtk-methodoflines-depot GROUP=2D_Diffusion timeout 7200 julia +1.12 --startup-file=no --project=downstream -e 'using Pkg; Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase")); Pkg.develop(PackageSpec(path=".")); Pkg.update(); Pkg.test(coverage=true)'
```

```text
Test Summary: | Error  Total  Time
2D_Diffusion  |     2      2  18.2s
ERROR: Package MethodOfLines errored during testing
UndefVarError: `discretize` not defined in `ModelingToolkit`
```

### Passing after the fix

The same checkout, depot, and test group with this MethodOfLines branch developed:

```sh
JULIA_DEPOT_PATH=../.mtk-methodoflines-depot GROUP=2D_Diffusion timeout 7200 julia +1.12 --startup-file=no --project=../.methodoflines-discretize-fix -e 'using Pkg; Pkg.develop(PackageSpec(path="./lib/ModelingToolkitBase")); Pkg.develop(PackageSpec(path=".")); Pkg.update(); Pkg.test(coverage=true)'
```

```text
Test Summary: | Pass  Total     Time
2D_Diffusion  |    2      2  4m16.3s
Testing MethodOfLines tests passed
```

Additional local groups against the same clean ModelingToolkit checkout:

- `GROUP=MOL_Interface1`: completed without errors, 0 assertions, 12m21.2s.
- `GROUP=Nonlinear_Diffusion`: 10 passed, 2 pre-existing broken, 7m08.9s.
- `GROUP=Nonlinear_Diffusion_NU`: 13 passed, 2 pre-existing broken, 6m42.2s.
- `GROUP=QA`: 12 passed, 6 pre-existing broken, 7m37.0s.
- Runic 1.8.0 `--check` on all four changed files: exit 0.
- `typos` over the zero-context diff: exit 0.
- `git diff --check`: exit 0.

## Not verified

- `GROUP=Everything` was not run; the affected groups and QA were run individually.
- Docs were not built because this changes test callers only and does not change public API, docstrings, or documentation.
- Julia LTS on current MethodOfLines `master` already has a separate `cartesian_nonlinear_laplacian` failure in `2D_Diffusion`: https://github.com/SciML/MethodOfLines.jl/actions/runs/32003104117/job/95309268460. This PR does not silence or change that path.
