### PR TITLE
Fix nonlinear Laplacian coordinate ordering

### DIFF
--- a/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
+++ b/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
@@ -33,6 +33,7 @@ function cartesian_nonlinear_laplacian(
     bs = filter_interfaces(bcmap[operation(u)][x])
     N = ndims(u, s)
     N == 0 && return 0
+    u_ivs = ivs(u, s)
     jx = j, x = (x2i(s, u, x), x)
 
     D_inner = derivweights.halfoffsetmap[1][Differential(x)]
@@ -78,7 +79,7 @@ function cartesian_nonlinear_laplacian(
                     weights, getindex.((s.grid[x],), getindex.(interface_wrap(stencil), (j,)))
                 ),
             ],
-            [s.x̄[k] => s.grid[s.x̄[k]][II[k]] for k in setdiff(1:N, [j])]
+            [u_ivs[k] => s.grid[u_ivs[k]][II[k]] for k in setdiff(1:N, [j])]
         )
     end
 


### PR DESCRIPTION
## What changed

Use the dependent variable's independent-variable order when mapping untouched coordinates inside the Cartesian nonlinear-Laplacian discretization. `II` is indexed according to `ivs(u, s)`, so pairing it with the independently ordered global `s.x̄` vector can select the wrong grid and raise a bounds error on asymmetric grids.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failure boundary

The last green LTS job used Julia 1.10.11 and the first red LTS job used Julia 1.10.12. Both resolved ModelingToolkit 11.39.0, PDEBase 0.1.32, Symbolics 7.36.0, and SymbolicUtils 4.45.0.

- Green 1.10.11 job: https://github.com/SciML/MethodOfLines.jl/actions/runs/31918121047/job/95094179506
- Red 1.10.12 job: https://github.com/SciML/MethodOfLines.jl/actions/runs/32003104117/job/95309268460

The only MethodOfLines source commit between those jobs was documentation-focused `98de1602`. I checked out the green source revision `17bec5e64f0d2931c645dda2caddba20d31ada79` and resolved today's dependency set on Julia 1.10.12; the same failure reproduced. Conversely, current master `98de1602e13d7bc5e171722dd7e0191e2f0fc02c` passed on Julia 1.10.11 with the same package versions.

The nested exception on Julia 1.10.12 was:

```text
BoundsError: attempt to access 11-element StepRangeLen ... at index [12]
```

At that point, `II == CartesianIndex(12, 2)` followed `ivs(u, s) == [x, y]`, while `s.x̄ == [y, x]` and the grid lengths were `[11, 21]`. The old code therefore treated `II[1]` as a `y` coordinate.

## Verification

### Failing before the fix

```sh
JULIA_DEPOT_PATH=.methodoflines-lts-nonlinear-depot GROUP=2D_Diffusion timeout 7200 julia +lts --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
```

On Julia 1.10.12 and clean master:

```text
Test Summary: | Pass  Error  Total     Time
2D_Diffusion  |    1      1      2  1m56.7s
ERROR: Some tests did not pass: 1 passed, 0 failed, 1 errored, 0 broken.
```

### Passing after the fix

The same command, Julia version, depot, group, and dependency resolution:

```text
Test Summary: | Pass  Total     Time
2D_Diffusion  |    2      2  2m49.1s
Testing MethodOfLines tests passed
```

The existing asymmetric-grid nonlinear 2D test is the discriminating regression test: it fails before this source change and passes after it, so this PR does not duplicate that expensive integration case.

Additional local verification:

- Julia 1.10.11, current master before the fix: `2D_Diffusion` 2/2 passed in 2m44.8s.
- Julia 1.12.7 after the fix: `2D_Diffusion` 2/2 passed in 4m09.8s.
- Julia 1.12.7 `GROUP=QA`: 12 passed, 6 pre-existing broken, 18 total in 7m28.7s.
- Julia Runic 1.8.0 `--check` on the changed file: exit 0.
- `typos` over the zero-context diff: exit 0.
- `git diff --check`: exit 0.

## Not verified

- `GROUP=Everything` was not run; the exact affected group was run on Julia 1.10.12 and 1.12.7, and QA was run separately.
- Julia pre was not run.
- Docs were not built because this changes one internal coordinate lookup and does not change public API, docstrings, or documentation.
