### PR TITLE
Fix hash-order-dependent IV indexing in nonlinear Laplacian discretization

### DIFF
--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -347,13 +347,6 @@ end
 
 valmaps(s, u, depvars, indexmap) = valmaps.([s], [u], [depvars], s.Igrid[u], [indexmap])
 
-function map_symbolic_to_discrete(II::CartesianIndex, s::DiscreteSpace{N, M}) where {N, M}
-    return vcat(
-        [s.ū[k] => s.discvars[k][II] for k in 1:M],
-        [s.x̄[j] => s.grid[j][II[j]] for j in 1:N]
-    )
-end
-
 # TODO: Allow other grids
 
 @inline function generate_grid(

--- a/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
+++ b/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
@@ -78,7 +78,7 @@ function cartesian_nonlinear_laplacian(
                     weights, getindex.((s.grid[x],), getindex.(interface_wrap(stencil), (j,)))
                 ),
             ],
-            [s.x̄[k] => s.grid[s.x̄[k]][II[k]] for k in setdiff(1:N, [j])]
+            transverse_iv_substitutions(s, u, II, x)
         )
     end
 
@@ -100,6 +100,15 @@ function cartesian_nonlinear_laplacian(
 
     # multiply the inner finite difference by the interpolated expression, and finally take the outer finite difference
     return sym_dot(outerweights, interpolated_expr)
+end
+
+"""
+Substitution rules for independent variables that are not the derivative
+direction `x`. Values are taken from the argument-ordered index `II` via
+`x2i`, never from the hash-order-dependent `s.x̄` permutation.
+"""
+function transverse_iv_substitutions(s::DiscreteSpace, u, II, x)
+    return [x_ => s.grid[x_][II[x2i(s, u, x_)]] for x_ in ivs(u, s) if !isequal(x_, x)]
 end
 
 function generate_deriv_rules(

--- a/src/discretization/schemes/spherical_laplacian/spherical_laplacian.jl
+++ b/src/discretization/schemes/spherical_laplacian/spherical_laplacian.jl
@@ -14,24 +14,27 @@ function spherical_diffusion(innerexpr, II, derivweights, s, indexmap, bcmap, de
     D_1 = derivweights.map[Differential(r)]
     D_2 = derivweights.map[Differential(r)^2]
 
-    #TODO!: Update this to use indvars of the pde
-    # What to replace parameter x with given I
-    _rsubs(x, I) = x => s.grid[x][I[s.x2i[x]]]
+    # What to replace parameter x with given I. `II` is argument-ordered
+    # (`x2i(s, u, x)`), not `s.x̄`-ordered (`s.x2i`).
+    _rsubs(x, I) = x => s.grid[x][I[x2i(s, u, x)]]
     # Full rules for substituting parameters in the inner expression
     function rsubs(I)
-        return safe_vcat([v => s.discvars[v][I] for v in depvars], [_rsubs(x, I) for x in s.x̄])
+        return safe_vcat(
+            [v => s.discvars[v][I] for v in depvars], [_rsubs(x, I) for x in ivs(u, s)]
+        )
     end
     # Discretization func for u
     ufunc_u(v, I, x) = s.discvars[v][I]
+    jr = x2i(s, u, r)
 
     # 2nd order finite difference in u
     exprhere = Num(substitute(innerexpr, Dict(rsubs(II))))
     # Catch the r ≈ 0 case
     if isapprox(unwrap_const(Symbolics.unwrap(substitute(r, _rsubs(r, II)))), 0, atol = 1.0e-6)
-        D_2_u = central_difference(D_2, II, s, bs, (s.x2i[r], r), u, ufunc_u)
+        D_2_u = central_difference(D_2, II, s, bs, (jr, r), u, ufunc_u)
         return 6exprhere * D_2_u # See appendix B of the paper
     end
-    D_1_u = central_difference(D_1, II, s, bs, (s.x2i[r], r), u, ufunc_u)
+    D_1_u = central_difference(D_1, II, s, bs, (jr, r), u, ufunc_u)
     # See scheme 1 in appendix A of the paper
 
     return exprhere * (

--- a/test/Components/nonlinear_laplacian_ivs.jl
+++ b/test/Components/nonlinear_laplacian_ivs.jl
@@ -1,0 +1,66 @@
+using ModelingToolkit, MethodOfLines, DomainSets, Test
+
+@testset "Transverse IV substitutions follow argument order, not s.x̄" begin
+    @parameters t x y
+    @variables u(..)
+
+    t_min = 0.0
+    t_max = 2.0
+    x_min = 0.0
+    x_max = 2.0
+    y_min = 0.0
+    y_max = 2.0
+    # Equal spacing: the historical `s.x̄[k] => grid[s.x̄[k]][II[k]]` mix-up does
+    # not BoundsError when nx == ny; it silently substitutes the wrong coordinate.
+    dx = dy = 0.2
+
+    domains = [
+        t ∈ Interval(t_min, t_max), x ∈ Interval(x_min, x_max), y ∈ Interval(y_min, y_max),
+    ]
+    pde = Differential(t)(u(t, x, y)) ~
+        Differential(x)(x * Differential(x)(u(t, x, y))) +
+        Differential(y)(y * Differential(y)(u(t, x, y)))
+    bcs = [
+        u(t_min, x, y) ~ 0,
+        u(t, x_min, y) ~ 0,
+        u(t, x_max, y) ~ 0,
+        u(t, x, y_min) ~ 0,
+        u(t, x, y_max) ~ 0,
+    ]
+    @named pdesys = PDESystem([pde], bcs, domains, [t, x, y], [u(t, x, y)])
+    disc = MOLFiniteDifference([x => dx, y => dy], t)
+    s = MethodOfLines.construct_discrete_space(MethodOfLines.VariableMap(pdesys, disc), disc)
+    uvar = s.ū[1]
+
+    function assert_argument_ordered(s, uvar, x, y)
+        II = CartesianIndex(8, 3)
+        y_rules = MethodOfLines.transverse_iv_substitutions(s, uvar, II, y)
+        x_rules = MethodOfLines.transverse_iv_substitutions(s, uvar, II, x)
+        @test length(y_rules) == 1
+        @test isequal(first(y_rules[1]), x)
+        @test last(y_rules[1]) == s.grid[x][8]
+        @test length(x_rules) == 1
+        @test isequal(first(x_rules[1]), y)
+        @test last(x_rules[1]) == s.grid[y][3]
+    end
+
+    assert_argument_ordered(s, uvar, x, y)
+
+    # Force the historically-broken VariableMap order so this test does not
+    # depend on SymbolicUtils Set iteration.
+    xbar = s.x̄
+    if xbar isa AbstractVector
+        reverse!(xbar)
+    end
+    assert_argument_ordered(s, uvar, x, y)
+
+    # Unequal grids: the CI failure indexed y's 11-point grid at 12.
+    disc2 = MOLFiniteDifference([x => 0.1, y => 0.2], t)
+    s2 = MethodOfLines.construct_discrete_space(MethodOfLines.VariableMap(pdesys, disc2), disc2)
+    u2 = s2.ū[1]
+    II = CartesianIndex(12, 3)
+    y_rules = MethodOfLines.transverse_iv_substitutions(s2, u2, II, y)
+    @test isequal(first(y_rules[1]), x)
+    @test last(y_rules[1]) == s2.grid[x][12]
+    @test last(y_rules[1]) != s2.grid[y][3]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,9 @@ run_tests(;
             @safetestset "Discretization of space and grid types" begin
                 include(joinpath(@__DIR__, "Components", "DiscreteSpace.jl"))
             end
+            @safetestset "Nonlinear laplacian IV interpolation order" begin
+                include(joinpath(@__DIR__, "Components", "nonlinear_laplacian_ivs.jl"))
+            end
             @safetestset "Variable PDE mapping and interior construction" begin
                 include(joinpath(@__DIR__, "Components", "interiormap_test.jl"))
             end


### PR DESCRIPTION
## Summary

`2D_Diffusion` Test 01 (`Dt(u) ~ Dx(a Dx(u)) + Dy(a Dy(u))`) errors during `discretize` on `master` and on unrelated PRs, including both `Tests / 2D_Diffusion (julia lts)` and `Downgrade / Downgrade Tests`. The two CI jobs share the same failure.

The crash is a `BoundsError` on the 11-point `y` grid at index `12`. That index is an interior `x` index (`dx = 0.1` → 21 points) applied to `y` (`dy = 0.2` → 11 points).

## Root cause

`cartesian_nonlinear_laplacian` interpolated the transverse coordinates with

```julia
[s.x̄[k] => s.grid[s.x̄[k]][II[k]] for k in setdiff(1:N, [j])]
```

`II` and `j = x2i(s, u, x)` are argument-ordered (`u(t, x, y)` → `[x, y]`). `s.x̄` is not: PDEBase `VariableMap` builds it from a `Set` union whose iteration order depends on SymbolicUtils hashing. Under SymbolicUtils v4 this can be `x̄ = [y, x]`. The `y`-direction rule then reads `s.grid[y][i_x]`, which throws when `i_x > length(y)`.

When `dx == dy` the same mix-up does not throw; it silently substitutes the wrong coordinate.

## Fix

- Nonlinear Laplacian: transverse IV substitutions go through `ivs(u, s)` and `x2i(s, u, x_)`, never `s.x̄` position.
- Spherical Laplacian: the same convention (`I[s.x2i[x]]` / `(s.x2i[r], r)` were `s.x̄`-ordered).
- Remove unused, broken `map_symbolic_to_discrete` (`s.grid[j]` with an `Int` key).

A PDEBase change to make `VariableMap.x̄` deterministic is left for a follow-up. This PR is sufficient to make MOL correct regardless of `x̄` permutation.

## Tests

`test/Components/nonlinear_laplacian_ivs.jl` checks the mapping for:

- equal grids (`dx == dy`), where the old code would silently swap coordinates
- unequal grids (`dx ≠ dy`), the CI `BoundsError`
- a forced reversed `s.x̄`, so the test does not depend on Set iteration order