### PR TITLE
docs: add v1 breaking-change migration notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,17 @@
 
 ## Breaking changes
 
-MethodOfLines now preserves the array structure of a spatial discretization. Interior
-equations are represented as symbolic operations over array slices instead of one scalar
-equation per grid point. This substantially reduces symbolic compilation work for large
-grids. Code that directly inspects or transforms the system returned by
-`symbolic_discretize` must now handle symbolic array equations. Call `mtkcompile` when a
-compiled, scalarized system is required.
+With a `DAEProblem`, MethodOfLines v1.0 makes symbolic compilation O(1) with respect to
+the number of grid points. Instead of generating and compiling one symbolic equation per
+grid point, it generates operations over whole array slices. Compilation can therefore be
+orders of magnitude faster than before, so `DAEProblem` is now the default for
+time-dependent systems.
 
-For time-dependent systems, `discretize` now normally returns a `DAEProblem` without first
-calling `mtkcompile`. Existing code that passes an ODE solver directly to the result, such
-as
+The system returned by `symbolic_discretize` now contains these symbolic array equations.
+Code that directly inspects or transforms that system must handle them.
+
+`discretize` now normally returns a `DAEProblem` without first calling `mtkcompile`.
+Existing code that passes an ODE solver directly to the result, such as
 
 ```julia
 prob = discretize(pdesys, discretization)
@@ -27,17 +28,15 @@ prob = discretize(pdesys, discretization)
 sol = solve(prob)
 ```
 
-If an explicit Runge–Kutta method such as `Tsit5()` or `SSPRK54()` is required, explicitly
-construct the compiled `ODEProblem`:
+The O(1) compilation improvement does not apply to an `ODEProblem`: compiling one
+scalarizes the array equations. Explicit Runge–Kutta methods such as `Tsit5()` and
+`SSPRK54()` require an `ODEProblem`, so construct one explicitly:
 
 ```julia
 sys, tspan = symbolic_discretize(pdesys, discretization)
 prob = ODEProblem(mtkcompile(sys), nothing, tspan)
 sol = solve(prob, Tsit5())
 ```
-
-Compiling the `ODEProblem` scalarizes the array equations, so this path does not retain the
-symbolic scaling benefit of the default DAE path.
 
 Systems that cannot be represented by the first-order DAE path automatically fall back to
 a compiled `ODEProblem`. Time-independent systems continue to produce a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,45 @@
+# MethodOfLines.jl 1.0
+
+## Breaking changes
+
+MethodOfLines now preserves the array structure of a spatial discretization. Interior
+equations are represented as symbolic operations over array slices instead of one scalar
+equation per grid point. This substantially reduces symbolic compilation work for large
+grids. Code that directly inspects or transforms the system returned by
+`symbolic_discretize` must now handle symbolic array equations. Call `mtkcompile` when a
+compiled, scalarized system is required.
+
+For time-dependent systems, `discretize` now normally returns a `DAEProblem` without first
+calling `mtkcompile`. Existing code that passes an ODE solver directly to the result, such
+as
+
+```julia
+prob = discretize(pdesys, discretization)
+sol = solve(prob, Tsit5())
+```
+
+must choose one of the following paths.
+
+Use the array-form `DAEProblem` and let OrdinaryDiffEq select its default DAE solver:
+
+```julia
+prob = discretize(pdesys, discretization)
+sol = solve(prob)
+```
+
+If an explicit Runge–Kutta method such as `Tsit5()` or `SSPRK54()` is required, explicitly
+construct the compiled `ODEProblem`:
+
+```julia
+sys, tspan = symbolic_discretize(pdesys, discretization)
+prob = ODEProblem(mtkcompile(sys), nothing, tspan)
+sol = solve(prob, Tsit5())
+```
+
+Compiling the `ODEProblem` scalarizes the array equations, so this path does not retain the
+symbolic scaling benefit of the default DAE path.
+
+Systems that cannot be represented by the first-order DAE path automatically fall back to
+a compiled `ODEProblem`. Time-independent systems continue to produce a
+`NonlinearProblem`. Solutions remain wrapped as `PDETimeSeriesSolution`, and PDE-variable
+indexing and interpolation are unchanged.

--- a/docs/src/MOLFiniteDifference.md
+++ b/docs/src/MOLFiniteDifference.md
@@ -100,7 +100,7 @@ Note that `mtkcompile` scalarizes the array equations, so this path gives up the
 benefit of the array form. Prefer `discretize` unless you specifically need an
 `ODEProblem` or an explicit time-stepping method.
 
-## Migrating to v1
+## [Migrating to v1](@id migrating-to-v1)
 
 - `discretize` returns a `DAEProblem` rather than an `ODEProblem` for time-dependent
   systems. Call `solve(prob)` to use the default DAE algorithm. Explicit Runge–Kutta

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,14 @@
 # [MethodOfLines.jl: Automated Finite Difference for Physics-Informed Learning](@id index)
 
+!!! warning "MethodOfLines v1.0 changes"
+    MethodOfLines v1.0 preserves spatial discretizations in symbolic array form. For
+    time-dependent systems, `discretize` now normally returns a `DAEProblem`; call
+    `solve(prob)` to use the default DAE solver.
+
+    Explicit Runge–Kutta methods such as `Tsit5()` and `SSPRK54()` require the compiled
+    ODE path: `symbolic_discretize`, then `mtkcompile`, then `ODEProblem`. See the
+    [v1.0 migration guide](@ref migrating-to-v1) for examples and compatibility details.
+
 [MethodOfLines.jl](https://github.com/SciML/MethodOfLines.jl)
 is a Julia package for automated finite difference discretization
 of symbolically-defined PDEs in N dimensions.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,13 +1,15 @@
 # [MethodOfLines.jl: Automated Finite Difference for Physics-Informed Learning](@id index)
 
 !!! warning "MethodOfLines v1.0 changes"
-    MethodOfLines v1.0 preserves spatial discretizations in symbolic array form. For
-    time-dependent systems, `discretize` now normally returns a `DAEProblem`; call
+    With a `DAEProblem`, MethodOfLines v1.0 makes symbolic compilation O(1) with respect
+    to the number of grid points and can be orders of magnitude faster than before.
+    `DAEProblem` is therefore the new default for time-dependent systems; call
     `solve(prob)` to use the default DAE solver.
 
-    Explicit Runge–Kutta methods such as `Tsit5()` and `SSPRK54()` require the compiled
-    ODE path: `symbolic_discretize`, then `mtkcompile`, then `ODEProblem`. See the
-    [v1.0 migration guide](@ref migrating-to-v1) for examples and compatibility details.
+    This improvement does not apply to `ODEProblem`. Explicit Runge–Kutta methods such as
+    `Tsit5()` and `SSPRK54()` require the compiled ODE path: `symbolic_discretize`, then
+    `mtkcompile`, then `ODEProblem`. See the [v1.0 migration guide](@ref migrating-to-v1)
+    for examples and compatibility details.
 
 [MethodOfLines.jl](https://github.com/SciML/MethodOfLines.jl)
 is a Julia package for automated finite difference discretization


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

Add `NEWS.md` for MethodOfLines v1.0. It explains that the `DAEProblem` path compiles operations over whole array slices, making symbolic compilation O(1) with respect to the number of grid points and potentially orders of magnitude faster than before. `DAEProblem` is therefore the new default for time-dependent systems.

The caveat is stated directly: this scaling improvement does not apply to `ODEProblem`, whose compilation scalarizes the equations. Explicit Runge–Kutta methods therefore require the documented path through `symbolic_discretize`, `mtkcompile`, and `ODEProblem`.

Add the same warning at the top of the documentation homepage with a link to the detailed v1 migration guide. The release notes intentionally do not frame recently introduced discretization-strategy type names as user-facing breaking changes. They also state the unchanged behavior for stationary problems, solution wrapping, indexing, and automatic fallback.

## Verification

- `/home/crackauc/.juliaup/bin/julia +release -m Runic --check src test docs benchmark`
  - exit code 0
- `typos NEWS.md docs/src/index.md docs/src/MOLFiniteDifference.md`
  - exit code 0
- `git diff --check`
  - exit code 0

## Not verified locally

Per maintainer direction, the documentation build and `GROUP=QA` run were stopped before completion, and no runtime test group was run for this documentation-only change. GitHub CI was not awaited before reporting the PR.

## Links

- MethodOfLines v1 implementation: https://github.com/SciML/MethodOfLines.jl/pull/650
- Discretization cleanup: https://github.com/SciML/MethodOfLines.jl/pull/651