### PR TITLE
Discretize grid-varying factors on nonlinear and spherical Laplacians

### DIFF
--- a/src/discretization/discretize_equations.jl
+++ b/src/discretization/discretize_equations.jl
@@ -1443,7 +1443,7 @@ function match_nonlinlap_terms(terms, s, depvars)
                     any(y -> subsmatch(pre, safe_unwrap(y) => nothing), s.x̄)
                 throw(
                     ArrayFormFallback(
-                        "grid-varying factor $(m.pre) multiplying a nonlinear laplacian, which the pointwise path leaves undiscretized"
+                        "grid-varying factor $(m.pre) multiplying a nonlinear laplacian has no slice form yet"
                     )
                 )
             end
@@ -1733,7 +1733,7 @@ function match_spherical_terms(terms, s, depvars, nllap_matches)
                     any(y -> subsmatch(pre, safe_unwrap(y) => nothing), s.x̄)
                 throw(
                     ArrayFormFallback(
-                        "grid-varying factor $(m.pre) multiplying a spherical laplacian, which the pointwise path leaves undiscretized"
+                        "grid-varying factor $(m.pre) multiplying a spherical laplacian has no slice form yet"
                     )
                 )
             end

--- a/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
+++ b/src/discretization/schemes/nonlinear_laplacian/nonlinear_laplacian.jl
@@ -150,9 +150,19 @@ function generate_deriv_rules(
     end
 end
 
+"""
+Evaluate `ex` at the grid point `II` by substituting dependent variables with their
+discrete counterparts and independent variables with their grid values. Rules that
+replace a whole matched term must pass every captured factor through this, as the
+general variable/grid substitution rules never reach a rule's output.
+"""
 function replacevals(ex, s, u, depvars, II, indexmap)
     rules = valmaps(s, u, depvars, II, indexmap)
     return substitute(ex, Dict(rules))
+end
+
+function replacevals(exs::AbstractVector, s, u, depvars, II, indexmap)
+    return map(ex -> replacevals(ex, s, u, depvars, II, indexmap), exs)
 end
 
 @inline function generate_nonlinlap_rules(
@@ -169,12 +179,12 @@ end
                             $(Differential(x))(*(~~a, $(Differential(x))(u), ~~b)),
                             ~~d
                         ) => *(
-                            ~c...,
+                            replacevals(~c, s, u, depvars, II, indexmap)...,
                             cartesian_nonlinear_laplacian(
                                 *(~a..., ~b...), Idx(II, s, u, indexmap),
                                 derivweights, s, indexmap, bcmap, depvars, x, u
                             ),
-                            ~d...
+                            replacevals(~d, s, u, depvars, II, indexmap)...
                         ) for x in ivs(u, s)
                     ]
                 ) for u in depvars
@@ -243,8 +253,8 @@ end
                                 ($(Differential(x))($(Differential(x))(u) / ~a)),
                                 ~~c
                             ) => *(
-                                ~b...,
-                                ~c...,
+                                replacevals(~b, s, u, depvars, II, indexmap)...,
+                                replacevals(~c, s, u, depvars, II, indexmap)...,
                                 cartesian_nonlinear_laplacian(
                                     1 / ~a, Idx(II, s, u, indexmap), derivweights,
                                     s, indexmap, bcmap, depvars, x, u
@@ -270,8 +280,8 @@ end
                                 ~e
                             ) => /(
                                 *(
-                                    ~b...,
-                                    ~c...,
+                                    replacevals(~b, s, u, depvars, II, indexmap)...,
+                                    replacevals(~c, s, u, depvars, II, indexmap)...,
                                     cartesian_nonlinear_laplacian(
                                         *(~a..., ~d...), Idx(II, s, u, indexmap),
                                         derivweights, s, indexmap, bcmap, depvars, x, u

--- a/src/discretization/schemes/spherical_laplacian/spherical_laplacian.jl
+++ b/src/discretization/schemes/spherical_laplacian/spherical_laplacian.jl
@@ -59,12 +59,12 @@ end
                             ($(Differential(r))(*(~~c, (r^2), ~~d, $(Differential(r))(u), ~~e))),
                             ~~b
                         ) => *(
-                            ~a...,
+                            replacevals(~a, s, u, depvars, II, indexmap)...,
                             spherical_diffusion(
                                 *(~c..., ~d..., ~e..., Num(1)), Idx(II, s, u, indexmap),
                                 derivweights, s, indexmap, bcmap, depvars, r, u
                             ),
-                            ~b...
+                            replacevals(~b, s, u, depvars, II, indexmap)...
                         )
                         for r in ivs(u, s)
                     ]
@@ -90,8 +90,8 @@ end
                                 ),
                                 (r^2)
                             ) => *(
-                                ~a...,
-                                ~b...,
+                                replacevals(~a, s, u, depvars, II, indexmap)...,
+                                replacevals(~b, s, u, depvars, II, indexmap)...,
                                 spherical_diffusion(
                                     *(~c..., ~d..., ~e..., Num(1)), Idx(II, s, u, indexmap),
                                     derivweights, s, indexmap, bcmap, depvars, r, u

--- a/test/Discretization/equation_discretization.jl
+++ b/test/Discretization/equation_discretization.jl
@@ -506,6 +506,31 @@ end
     @test narrayeqs_interior(sys_arr) == 1
 end
 
+@testset "1D nonlinear laplacian, grid-varying factor multiplying the laplacian" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    bcs = [u(0, x) ~ 1.0 + sinpi(x) / 2, u(t, 0) ~ 1.0, u(t, 1) ~ 1.0]
+    domains = [t ∈ Interval(0.0, 0.05), x ∈ Interval(0.0, 1.0)]
+
+    eqs = [
+        # An independent variable factor
+        Dt(u(t, x)) ~ x * Dx(u(t, x)^2 * Dx(u(t, x))),
+        # A dependent variable factor
+        Dt(u(t, x)) ~ u(t, x) * Dx(u(t, x)^2 * Dx(u(t, x))),
+        # A factor on the divided-coefficient form
+        Dt(u(t, x)) ~ x * Dx(Dx(u(t, x)) / u(t, x)),
+        # A grid-varying factor together with a grid-varying divisor
+        Dt(u(t, x)) ~ (1 + x) * Dx(u(t, x)^2 * Dx(u(t, x))) / (2 + x),
+    ]
+    for eq in eqs
+        @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+        sol_arr, _ = solve_discretized(pdesys, [x => 0.05], t)
+        @test SciMLBase.successful_retcode(sol_arr)
+    end
+end
+
 @testset "1D nonlinear laplacian, fourth order approximation" begin
     # Band regression guard: at order 4 the half-offset operators are wider than the
     # central second difference `d_orders` reports, so the core must shrink accordingly.
@@ -698,6 +723,32 @@ end
     sol_arr, sys_arr = solve_discretized(pdesys, [r => 0.1], t)
     @test sol_arr.retcode == SciMLBase.ReturnCode.Success
     @test narrayeqs_interior(sys_arr) == 1
+end
+
+@testset "1D spherical laplacian, grid-varying factor multiplying the laplacian" begin
+    @parameters t r
+    @variables u(..)
+    Dt = Differential(t)
+    Dr = Differential(r)
+
+    bcs = [
+        u(0, r) ~ sin(r) / r,
+        Dr(u(t, 0)) ~ 0.0,
+        u(t, 1) ~ exp(-t) * sin(1.0),
+    ]
+    domains = [t ∈ Interval(0.0, 1.0), r ∈ Interval(0.0, 1.0)]
+
+    eqs = [
+        # An independent variable factor
+        Dt(u(t, r)) ~ (1 + r) * Dr(r^2 * Dr(u(t, r))) / r^2,
+        # A dependent variable factor
+        Dt(u(t, r)) ~ u(t, r) * Dr(r^2 * Dr(u(t, r))) / r^2,
+    ]
+    for eq in eqs
+        @named pdesys = PDESystem(eq, bcs, domains, [t, r], [u(t, r)])
+        sol_arr, _ = solve_discretized(pdesys, [r => 0.1], t)
+        @test SciMLBase.successful_retcode(sol_arr)
+    end
 end
 
 @testset "1D spherical laplacian on a nonuniform grid" begin

--- a/test/MOL_Interface2/MOLtest2.jl
+++ b/test/MOL_Interface2/MOLtest2.jl
@@ -95,21 +95,21 @@ using Test
         diff_eq = ∂t(c(x, t)) ~ c(x, t) * ∂x(c(x, t) * ∂x(c(x, t)))
         @named pdesys = PDESystem(diff_eq, bcs, domains, [x, t], [c(x, t)])
         discretization = MOLFiniteDifference([x => Δx], t)
-        @test_broken discretize(pdesys, discretization) isa DAEProblem
+        @test discretize(pdesys, discretization) isa DAEProblem
     end
 
     @testset "Test 09: ∂t(c(x, t)) ~ c(x, t) * ∂x(c(x,t) * ∂x(c(x, t)))/(1+c(x,t))" begin
         diff_eq = c(x, t) * ∂x(c(x, t) * ∂x(c(x, t))) / (1 + c(x, t)) ~ 0
         @named pdesys = PDESystem(diff_eq, bcs, domains, [x, t], [c(x, t)])
         discretization = MOLFiniteDifference([x => Δx], t)
-        @test_broken discretize(pdesys, discretization) isa DAEProblem
+        @test discretize(pdesys, discretization) isa DAEProblem
     end
 
     @testset "Test 10: ∂t(c(x, t)) ~ c(x, t) * ∂x(c(x,t) * ∂x(c(x, t)))/(1+c(x,t))" begin
         diff_eq = c(x, t) * ∂x(c(x, t)^(-1) * ∂x(c(x, t))) ~ 0
         @named pdesys = PDESystem(diff_eq, bcs, domains, [x, t], [c(x, t)])
         discretization = MOLFiniteDifference([x => Δx], t)
-        @test_broken discretize(pdesys, discretization) isa DAEProblem
+        @test discretize(pdesys, discretization) isa DAEProblem
     end
 
     @testset "Test 11: ∂t(c(x, t)) ~ ∂x(1/(1+c(x,t)^2) ∂x(c(x, t)))" begin


### PR DESCRIPTION
Fixes #640.

`generate_nonlinlap_rules` and `generate_spherical_diffusion_rules` splice captured prefactors (`~~a`/`~~b`/`~~c`/`~~d`) back onto the replacement as-is. Because the rule keys on the whole term, `valmaps` never sees those factors, so a grid-varying `x` or `u` survives into the compiled system and `mtkcompile` fails.

Same treatment the divisor already had: pass the captured factors through `replacevals`. Also dropped the now-stale "pointwise path leaves this undiscretized" fallback wording.

Regression cases in `equation_discretization.jl` for iv/depvar prefactors on both operators.

Tests 08–10 in MOLtest2.jl were `@test_broken` because the grid-varying prefactor path used to fail. They compile now, so those are `@test` again.