### PR TITLE
Transfer MTK metadata from PDESystem to discretized System

### DIFF
--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -287,7 +287,7 @@ end
         ModelingToolkit.VariableStatePriority
         ModelingToolkit.VariableType
         ModelingToolkit.VariableUnit
-        ModelingToolkit.VariableNominal]
+        ModelingToolkitBase.VariableNominal]
     for ctx in METADATA
         if hasmetadata(original, ctx)
             arrvar = setmetadata(arrvar, ctx, getmetadata(original, ctx))

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -261,15 +261,38 @@ map dependent variables
         sym = nameof(op)
         if t === nothing
             uaxes = collect(axes(grid[x])[1] for x in arguments(u))
-            u => unwrap.(collect(first(@variables $sym[uaxes...])))
+            arrvar = unwrap(first(@variables $sym[uaxes...]))
+            arrvar = add_MTK_metadata(arrvar, u)
+            u => unwrap.(collect(arrvar))
         elseif isequal(SymbolicUtils.arguments(u), [t])
             u => fill(safe_unwrap(u), ()) #Create a 0-dimensional array
         else
             uaxes = collect(axes(grid[x])[1] for x in remove(arguments(u), t))
-            u => unwrap.(collect(first(@variables $sym(t)[uaxes...])))
+            arrvar = unwrap(first(@variables $sym(t)[uaxes...]))
+            arrvar = add_MTK_metadata(arrvar, u)
+            u => unwrap.(collect(arrvar))
         end
     end
     return depvarsdisc
+end
+
+@inline function add_MTK_metadata(arrvar, original)
+    METADATA = [ModelingToolkit.VariableBounds
+        ModelingToolkit.VariableConnectType
+        ModelingToolkit.VariableDescription
+        ModelingToolkit.VariableInput
+        ModelingToolkit.VariableIrreducible
+        ModelingToolkit.VariableMisc
+        ModelingToolkit.VariableOutput
+        ModelingToolkit.VariableStatePriority
+        ModelingToolkit.VariableType
+        ModelingToolkit.VariableUnit]
+    for ctx in METADATA
+        if hasmetadata(original, ctx)
+            arrvar = setmetadata(arrvar, ctx, getmetadata(original, ctx))
+        end
+    end
+    return arrvar
 end
 
 """

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -286,7 +286,8 @@ end
         ModelingToolkit.VariableOutput
         ModelingToolkit.VariableStatePriority
         ModelingToolkit.VariableType
-        ModelingToolkit.VariableUnit]
+        ModelingToolkit.VariableUnit
+        ModelingToolkit.VariableNominal]
     for ctx in METADATA
         if hasmetadata(original, ctx)
             arrvar = setmetadata(arrvar, ctx, getmetadata(original, ctx))

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -277,7 +277,8 @@ map dependent variables
 end
 
 @inline function add_MTK_metadata(arrvar, original)
-    METADATA = [ModelingToolkit.VariableBounds
+    METADATA = [
+        ModelingToolkit.VariableBounds
         ModelingToolkit.VariableConnectType
         ModelingToolkit.VariableDescription
         ModelingToolkit.VariableInput
@@ -287,7 +288,8 @@ end
         ModelingToolkit.VariableStatePriority
         ModelingToolkit.VariableType
         ModelingToolkit.VariableUnit
-        ModelingToolkitBase.VariableNominal]
+        ModelingToolkitBase.VariableNominal
+    ]
     for ctx in METADATA
         if hasmetadata(original, ctx)
             arrvar = setmetadata(arrvar, ctx, getmetadata(original, ctx))

--- a/src/discretization/discretize_vars.jl
+++ b/src/discretization/discretize_vars.jl
@@ -288,7 +288,6 @@ end
         ModelingToolkit.VariableStatePriority
         ModelingToolkit.VariableType
         ModelingToolkit.VariableUnit
-        ModelingToolkitBase.VariableNominal
     ]
     for ctx in METADATA
         if hasmetadata(original, ctx)

--- a/test/Components/metadata.jl
+++ b/test/Components/metadata.jl
@@ -60,5 +60,5 @@ include(joinpath(@__DIR__, "..", "shared", "ode_discretize.jl"))
     @test getmetadata(prob.f.sys.z, ModelingToolkit.VariableBounds) == (0.0, Inf)
     @test getmetadata(prob.f.sys.z, ModelingToolkit.VariableOutput) == true
 
-    @test length(analytically_integrated(prob)) == 6 # 3 for y and 3 for z
+    @test length(analytically_integrated(prob.f.sys)) == 6 # 3 for y and 3 for z
 end

--- a/test/Components/metadata.jl
+++ b/test/Components/metadata.jl
@@ -1,0 +1,64 @@
+using ModelingToolkit, MethodOfLines, DomainSets
+include(joinpath(@__DIR__, "..", "shared", "ode_discretize.jl"))
+
+@testset "MTK metadata should be passed to discretized variables" begin
+    # Parameters, variables, and derivatives
+    @parameters t x
+    @variables u(..) [input = true] g(..) [irreducible = true] y(..) z(..) [bounds = (0.0, Inf), output = true]
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dxx = Differential(x)^2
+
+    # 1D PDE and boundary conditions
+    eq = [Dt(u(t, x)) ~ Dxx(u(t, x)) + g(t, x) + y(t, x) + z(t, x),
+        Dt(g(t, x)) ~ 0,
+        Dt(y(t, x)) ~ 0,
+        Dt(z(t, x)) ~ 0]
+    bcs = [u(0, x) ~ sin(pi * x),
+        u(t, 0) ~ 0,
+        u(t, 1) ~ 0,
+        g(0, x) ~ 0,
+        Dx(g(t, 0)) ~ 0,
+        Dx(g(t, 1)) ~ 0,
+        y(0, x) ~ 0,
+        Dx(y(t, 0)) ~ 0,
+        Dx(y(t, 1)) ~ 0,
+        z(0, x) ~ 0,
+        Dx(z(t, 0)) ~ 0,
+        Dx(z(t, 1)) ~ 0]
+
+    # Space and time domains
+    domains = [t ∈ Interval(0.0, 0.01),
+        x ∈ Interval(0.0, 1.0)]
+
+    # PDE system
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [g(t, x), u(t, x), y(t, x), z(t, x)])
+
+    # Dependent variables have metadata
+    @test hasmetadata(pdesys.u, ModelingToolkit.VariableInput)
+    @test hasmetadata(pdesys.g, ModelingToolkit.VariableIrreducible)
+    @test hasmetadata(pdesys.z, ModelingToolkit.VariableBounds)
+    @test hasmetadata(pdesys.z, ModelingToolkit.VariableOutput)
+    @test getmetadata(pdesys.u, ModelingToolkit.VariableInput) == true
+    @test getmetadata(pdesys.g, ModelingToolkit.VariableIrreducible) == true
+    @test getmetadata(pdesys.z, ModelingToolkit.VariableBounds) == (0.0, Inf)
+    @test getmetadata(pdesys.z, ModelingToolkit.VariableOutput) == true
+
+    dx = 0.25
+    # Method of lines discretization
+    discretization = MOLFiniteDifference([x => dx], t)
+
+    # Convert the PDE problem into an ODE problem
+    prob = ode_discretize(pdesys, discretization)
+
+    @test hasmetadata(prob.f.sys.g, ModelingToolkit.VariableIrreducible)
+    @test hasmetadata(prob.f.sys.u, ModelingToolkit.VariableInput)
+    @test hasmetadata(prob.f.sys.z, ModelingToolkit.VariableBounds)
+    @test hasmetadata(prob.f.sys.z, ModelingToolkit.VariableOutput)
+    @test getmetadata(prob.f.sys.g, ModelingToolkit.VariableIrreducible) == true
+    @test getmetadata(prob.f.sys.u, ModelingToolkit.VariableInput) == true
+    @test getmetadata(prob.f.sys.z, ModelingToolkit.VariableBounds) == (0.0, Inf)
+    @test getmetadata(prob.f.sys.z, ModelingToolkit.VariableOutput) == true
+
+    @test length(analytically_integrated(prob)) == 6 # 3 for y and 3 for z
+end

--- a/test/Components/metadata.jl
+++ b/test/Components/metadata.jl
@@ -10,11 +10,14 @@ include(joinpath(@__DIR__, "..", "shared", "ode_discretize.jl"))
     Dxx = Differential(x)^2
 
     # 1D PDE and boundary conditions
-    eq = [Dt(u(t, x)) ~ Dxx(u(t, x)) + g(t, x) + y(t, x) + z(t, x),
+    eq = [
+        Dt(u(t, x)) ~ Dxx(u(t, x)) + g(t, x) + y(t, x) + z(t, x),
         Dt(g(t, x)) ~ 0,
         Dt(y(t, x)) ~ 0,
-        Dt(z(t, x)) ~ 0]
-    bcs = [u(0, x) ~ sin(pi * x),
+        Dt(z(t, x)) ~ 0,
+    ]
+    bcs = [
+        u(0, x) ~ sin(pi * x),
         u(t, 0) ~ 0,
         u(t, 1) ~ 0,
         g(0, x) ~ 0,
@@ -25,11 +28,14 @@ include(joinpath(@__DIR__, "..", "shared", "ode_discretize.jl"))
         Dx(y(t, 1)) ~ 0,
         z(0, x) ~ 0,
         Dx(z(t, 0)) ~ 0,
-        Dx(z(t, 1)) ~ 0]
+        Dx(z(t, 1)) ~ 0,
+    ]
 
     # Space and time domains
-    domains = [t ∈ Interval(0.0, 0.01),
-        x ∈ Interval(0.0, 1.0)]
+    domains = [
+        t ∈ Interval(0.0, 0.01),
+        x ∈ Interval(0.0, 1.0),
+    ]
 
     # PDE system
     @named pdesys = PDESystem(eq, bcs, domains, [t, x], [g(t, x), u(t, x), y(t, x), z(t, x)])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,9 @@ run_tests(;
             @safetestset "MOLFiniteDifference Interface: Staggered constructors" begin
                 include(joinpath(@__DIR__, "Components", "staggered_constructors.jl"))
             end
+            @safetestset "MTK Metadata" begin
+                include(joinpath(@__DIR__, "Components", "metadata.jl"))
+            end
             return @safetestset "Discrete Callbacks" begin
                 include(joinpath(@__DIR__, "Components", "callbacks.jl"))
             end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Any MTK metadata (those available as ModelingToolkit.Variable...) that is present in the PDESystem is now copied across to the final discretized system. This allows options like irreducible to be used to avoid simplifications and reductions on particular variables.

There are some metadata options that aren't included here (default, guess, disturbance, distribution, and tunable), since I don't think they work with `hasmetadata` and `getmetadata`, and there is no public setter for them.