### PR TITLE
Import Symbolics.@wrapped so MethodOfLines precompiles

### DIFF
--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -16,7 +16,7 @@ using SymbolicIndexingInterface: NotSymbolic, symbolic_type
 import SymbolicUtils
 using SymbolicUtils: @rule, hasmetadata, setmetadata, substitute, term
 import Symbolics
-using Symbolics: @variables, Differential, Equation, Integral, Num, terms
+using Symbolics: @variables, @wrapped, Differential, Equation, Integral, Num, terms
 using Symbolics: unwrap, symbolic_linear_solve, expand_derivatives, diff2term,
     symbolic_to_float
 using SymbolicUtils: operation, arguments, iscall, getmetadata, unwrap_const

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -7,6 +7,10 @@ run_qa(
     reexports_allow = (:discretize, :symbolic_discretize),
     aqua_kwargs = (; persistent_tasks = (; tmax = 300)),
     ei_kwargs = (;
+        no_stale_explicit_imports = (;
+            # `@register_array_symbolic` expands to `@wrapped` in this module.
+            ignore = (Symbol("@wrapped"),),
+        ),
         all_explicit_imports_are_public = (;
             # These are PDEBase/Symbolics developer hooks required to implement the
             # discretizer extension points; their owners have not declared them public.


### PR DESCRIPTION
#655 calls `Symbolics.@register_array_symbolic` for the array integral helpers. That macro escapes `@wrapped` into this module, and we only import a handful of Symbolics names, so `using MethodOfLines` dies with `UndefVarError: @wrapped not defined`.

Docs, downgrade, and the benchmark job all hit it. Benchmarks fail on `MethodOfLines@master` before they even look at a feature branch.

This just adds `@wrapped` to the existing `using Symbolics:` list.