### PR TITLE
Release 1.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]
@@ -47,7 +47,7 @@ StableRNGs = "1"
 StaticArrays = "1.9.18"
 SymbolicIndexingInterface = "0.3.44"
 SymbolicUtils = "4.34.3"
-Symbolics = "7.26"
+Symbolics = "7.38"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
Raise the Symbolics floor to 7.38 and release.

`@register_array_symbolic` escaped a bare `@wrapped` into the calling module, so `import MethodOfLines` failed with `UndefVarError: @wrapped not defined` and AutoMerge rejected the v1.1.1 registration. Symbolics 7.38.0 fixes the macro hygiene (JuliaSymbolics/Symbolics.jl#1972); the old floor of 7.26 still admitted the broken versions, so it is raised to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R