### PR TITLE
Set version back to 1.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "1.1.2"
+version = "1.1.1"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
v1.1.1 was never registered - AutoMerge rejected it because `import MethodOfLines` failed, and that PR was closed unmerged. The version number is therefore still free, so 1.1.2 would skip it and trips the sequential-version guideline. Restore 1.1.1, keeping the Symbolics 7.38 floor that actually fixes the load failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R