### PR TITLE
Stop infinite loop when a dependent variable is missing from PDESystem

### DIFF
--- a/src/system_parsing/pde_system_transformation.jl
+++ b/src/system_parsing/pde_system_transformation.jl
@@ -17,8 +17,16 @@ function PDEBase.transform_pde_system!(
             term, badterm, shouldexpand = descend_to_incompatible(eq.lhs, v)
             # Expand derivatives where possible
             if shouldexpand
+                expanded = expand_derivatives(term)
+                if isequal(expanded, term)
+                    throw(
+                        ArgumentError(
+                            "Could not expand derivatives in $term. If $badterm is a PDE unknown, add it to the PDESystem dependent-variable list."
+                        )
+                    )
+                end
                 @warn "Expanding derivatives in term $term."
-                rule = term => expand_derivatives(term)
+                rule = term => expanded
                 subs_alleqs!(eqs, bcs, rule)
                 done = false
                 break

--- a/test/Components/missing_dependent_variable.jl
+++ b/test/Components/missing_dependent_variable.jl
@@ -1,0 +1,24 @@
+using ModelingToolkit, MethodOfLines, DomainSets, Test
+
+@testset "Missing dependent variable throws ArgumentError" begin
+    @parameters t, v
+    @variables p(..) S(..)
+
+    Dt = Differential(t)
+    Dv = Differential(v)
+
+    eq = [
+        S(t, v) ~ -p(t, v) - Dv(p(t, v)),
+        Dt(p(t, v)) ~ -Dv(S(t, v)),
+    ]
+    bcs = [p(0.0, v) ~ 1.0, p(t, 20.0) ~ 0.0, Dv(p(t, -10.0)) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 1.0), v ∈ Interval(-10.0, 20.0)]
+    disc = MOLFiniteDifference([v => 5.0], t)
+
+    @named sys = PDESystem(eq, bcs, domains, [t, v], [p(t, v)])
+    term = Dv(S(t, v))
+    badterm = S(t, v)
+    @test_throws ArgumentError(
+        "Could not expand derivatives in $term. If $badterm is a PDE unknown, add it to the PDESystem dependent-variable list."
+    ) discretize(sys, disc)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,9 @@ run_tests(;
             @safetestset "MTK Metadata" begin
                 include(joinpath(@__DIR__, "Components", "metadata.jl"))
             end
+            @safetestset "Missing dependent variable" begin
+                include(joinpath(@__DIR__, "Components", "missing_dependent_variable.jl"))
+            end
             return @safetestset "Discrete Callbacks" begin
                 include(joinpath(@__DIR__, "Components", "callbacks.jl"))
             end


### PR DESCRIPTION
Fixes #475

`transform_pde_system!` retried `expand_derivatives` on the same term when a PDE unknown was not in the dependent-variable list, so it printed the same warning forever.

If expansion does not change the term, we now throw an `ArgumentError` pointing at the missing unknown. Added a regression test for the example in the issue.