### PR TITLE
Support vector-valued functions in ArrayDiscretization

### DIFF
--- a/src/discretization/discretize_equations.jl
+++ b/src/discretization/discretize_equations.jl
@@ -57,6 +57,9 @@
 # permuted and reshaped with singleton dimensions, matching `Idx`. A whole-domain
 # integrand with extra axes is a reduction (`array_integral_rules`), not a slice.
 #
+# Calls `f(u, θ)` map over the field slice without broadcasting `θ`.
+# `(f(u, θ))[i]` selects each point's output.
+#
 # Unsupported patterns fall back to pointwise equations: callbacks,
 # a higher-dimensional field whose extra axes are free (not a boundary
 # value and not an integral rank drop), derivatives of time-literals,
@@ -2805,6 +2808,49 @@ end
 # symbolic arrays and scalars of either kind.
 is_array_valued(x) = SymbolicUtils.symtype(safe_unwrap(x)) <: AbstractArray
 
+# Parameter arrays are not grid slices and are excluded from grid broadcasts.
+is_symbolic_parameter(x) = ModelingToolkitBase.isparameter(safe_unwrap(x))
+is_array_parameter(x) = is_array_valued(x) && is_symbolic_parameter(x)
+
+function is_field_parameter_call(args)
+    return length(args) == 2 && is_array_valued(args[1]) &&
+        !is_array_parameter(args[1]) && is_array_parameter(args[2])
+end
+
+array_map_callable(op, U::AbstractArray, θ) = map(ui -> op(ui, θ), U)
+Symbolics.@register_array_symbolic array_map_callable(
+    op::Any, U::AbstractArray, θ::AbstractArray
+) begin
+    size = size(U)
+    eltype = Real
+end
+
+array_map_callable_getindex(op, idx, U::AbstractArray, θ) =
+    map(ui -> getindex(op(ui, θ), idx), U)
+Symbolics.@register_array_symbolic array_map_callable_getindex(
+    op::Any, idx, U::AbstractArray, θ::AbstractArray
+) begin
+    size = size(U)
+    eltype = Real
+end
+
+function array_broadcast_call(op, newargs)
+    is_field_parameter_call(newargs) &&
+        return array_map_callable(op, newargs[1], newargs[2])
+    if any(is_array_parameter, newargs)
+        if op === getindex && length(newargs) == 2 &&
+                is_array_parameter(newargs[1]) && !is_array_valued(newargs[2])
+            return getindex(newargs[1], newargs[2])
+        end
+        throw(ArrayFormFallback("unhandled vector parameter in $op"))
+    end
+    any(is_array_valued, newargs) || return op(newargs...)
+    # `[u]` has no slice form; broadcasting the literal would wrap each point.
+    op isa Function && parentmodule(op) === SymbolicUtils && nameof(op) === :array_literal &&
+        throw(ArrayFormFallback("unhandled array literal of a field"))
+    return broadcast(op, newargs...)
+end
+
 function array_shape_donor(rules)
     for r in rules
         is_array_valued(r.second) && return r.second
@@ -2854,6 +2900,8 @@ matches a rule in `ctx.rules` (first match wins) and broadcasting any operation 
 receives an array-valued argument. Time differentials are applied directly to their
 (array-valued) arguments; any spatial differential that survives the rules means the
 expression contains a scheme this path does not support, so fall back.
+
+Calls `f(u, θ)` map over the field slice. Indexed calls select each point's output.
 """
 function arrayify(expr, ctx)
     expr = safe_unwrap(expr)
@@ -2872,16 +2920,29 @@ function arrayify(expr, ctx)
             throw(ArrayFormFallback("unhandled spatial derivative in $expr"))
         arg = arrayify(only(arguments(expr)), ctx)
         return op(arg)
-    elseif !(op isa Function)
+    end
+    # Index each point's callable output, not the mapped grid.
+    if op === getindex
+        args = arguments(expr)
+        if length(args) == 2
+            inner = safe_unwrap(args[1])
+            if iscall(inner)
+                iop = operation(inner)
+                if iop isa Function || is_symbolic_parameter(iop)
+                    iargs = [arrayify(a, ctx) for a in arguments(inner)]
+                    idx = arrayify(args[2], ctx)
+                    is_field_parameter_call(iargs) ||
+                        throw(ArrayFormFallback("unhandled callable getindex in $expr"))
+                    return array_map_callable_getindex(iop, idx, iargs[1], iargs[2])
+                end
+            end
+        end
+    end
+    if !(op isa Function) && !is_symbolic_parameter(op)
         # Symbolic operators (`Integral`, ...) cannot be broadcast over slices.
         throw(ArrayFormFallback("unhandled operation $op in $expr"))
     end
-    newargs = [arrayify(a, ctx) for a in arguments(expr)]
-    if any(is_array_valued, newargs)
-        return broadcast(op, newargs...)
-    else
-        return op(newargs...)
-    end
+    return array_broadcast_call(op, [arrayify(a, ctx) for a in arguments(expr)])
 end
 
 ####

--- a/test/Discretization/equation_discretization.jl
+++ b/test/Discretization/equation_discretization.jl
@@ -111,6 +111,125 @@ end
     @test maximum(abs.(sol_arr[u(t, x)] .- exact)) < 1.0e-2
 end
 
+# Parameterized calls keep `θ` whole.
+vecfn_scalar(u, θ) = θ[1] * u
+@register_symbolic vecfn_scalar(u, θ::AbstractVector)
+
+vecfn_array(u, θ) = [θ[1] * u]
+@register_array_symbolic vecfn_array(u::Real, θ::AbstractVector) begin
+    size = (1,)
+    eltype = Real
+end
+struct VectorFunctionWrapper end
+(::VectorFunctionWrapper)(u::Number, θ::AbstractVector) = [θ[1] * u]
+(::VectorFunctionWrapper)(u::AbstractVector, θ::AbstractVector) = [θ[1] * u[1]]
+const vecfn_wrapper = VectorFunctionWrapper()
+@parameters (vecfn_parameter::typeof(vecfn_wrapper))(..)[1:1] =
+    vecfn_wrapper [tunable = false]
+
+vecfn_rev(θ, u) = θ[1] * u
+@register_symbolic vecfn_rev(θ::AbstractVector, u)
+
+function test_parameterized_heat(source; parameters = Any[], map_name = nothing)
+    @parameters t x
+    @parameters θ[1:2] = [1.0, 0.0]
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + source(u(t, x), θ)
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
+    ps = Any[parameters..., θ]
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], ps)
+
+    disc = MOLFiniteDifference([x => 0.05], t)
+    sys_arr, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys_arr) == 1
+    if map_name !== nothing
+        int_eq = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys_arr)))
+        @test occursin(map_name, string(int_eq))
+    end
+    prob = discretize(pdesys, disc)
+    @test prob isa SciMLBase.DAEProblem
+    sol_arr = solve(prob)
+    @test successful_retcode(sol_arr)
+    xdisc = sol_arr[x]
+    tdisc = sol_arr[t]
+    exact = [exp((1 - pi^2) * ti) * sinpi(xi) for ti in tdisc, xi in xdisc]
+    @test maximum(abs.(sol_arr[u(t, x)] .- exact)) < 1.0e-2
+    return nothing
+end
+
+@testset "1D diffusion, array parameter as scalar coefficient" begin
+    test_parameterized_heat((u, θ) -> θ[1] * u)
+end
+
+@testset "1D diffusion with parameterized registered function" begin
+    test_parameterized_heat(
+        (u, θ) -> vecfn_scalar(u, θ); map_name = "array_map_callable("
+    )
+end
+
+@testset "1D diffusion with vector-valued registered function" begin
+    test_parameterized_heat(
+        (u, θ) -> vecfn_array(u, θ)[1];
+        map_name = "array_map_callable_getindex("
+    )
+end
+
+@testset "1D diffusion with callable vector parameter" begin
+    @test ModelingToolkitBase.isparameter(Symbolics.unwrap(vecfn_parameter))
+    test_parameterized_heat(
+        (u, θ) -> vecfn_parameter(u, θ)[1];
+        parameters = [vecfn_parameter],
+        map_name = "array_map_callable_getindex("
+    )
+end
+
+@testset "Unsupported vector-parameter call falls back" begin
+    @parameters t x
+    @parameters θ[1:2] = [1.0, 0.0]
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + vecfn_rev(θ, u(t, x))
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [θ])
+
+    disc = MOLFiniteDifference([x => 0.05], t)
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 0
+end
+
+@testset "Vector-input callable parameter falls back and solves" begin
+    @parameters t x
+    @parameters θ[1:2] = [1.0, 0.0]
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + vecfn_parameter([u(t, x)], θ)[1]
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
+    @named pdesys = PDESystem(
+        eq, bcs, domains, [t, x], [u(t, x)], [vecfn_parameter, θ]
+    )
+
+    disc = MOLFiniteDifference([x => 0.05], t)
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 0
+    prob = discretize(pdesys, disc)
+    sol = solve(prob)
+    @test successful_retcode(sol)
+    xdisc = sol[x]
+    tdisc = sol[t]
+    exact = [exp((1 - pi^2) * ti) * sinpi(xi) for ti in tdisc, xi in xdisc]
+    @test maximum(abs.(sol[u(t, x)] .- exact)) < 1.0e-2
+end
+
 @testset "1D diffusion, Neumann and Robin BCs" begin
     @parameters t x
     @variables u(..)


### PR DESCRIPTION
`f(u, θ)` and `(f(u, θ))[i]` (including `NN(u, θ)[1]`) were falling back to pointwise because `arrayify` treated `θ` as a grid slice. They now map over the field and keep `θ` whole, so the 1D heat + NN term stays one interior array equation on the DAE path.