### PR TITLE
Reconstruct array observables once per PDE field

### DIFF
--- a/src/interface/solution/timedep.jl
+++ b/src/interface/solution/timedep.jl
@@ -16,6 +16,26 @@ function SciMLBase.PDETimeSeriesSolution(
     return sol
 end
 
+function array_observed_solution(sol, discu, observed_equations)
+    for eq in observed_equations
+        lhs = Symbolics.wrap(eq.lhs)
+        lhs isa AbstractArray || continue
+        size(lhs) == size(discu) || continue
+        entries = Symbolics.scalarize(lhs)
+        all(isequal(safe_unwrap(entries[I]), safe_unwrap(discu[I])) for I in CartesianIndices(discu)) || continue
+        evaluator = SymbolicIndexingInterface.observed(sol, eq.lhs)
+        values = evaluator.(
+            SymbolicIndexingInterface.state_values(sol),
+            (SymbolicIndexingInterface.parameter_values(sol),),
+            SymbolicIndexingInterface.current_time(sol)
+        )
+        return map(CartesianIndices(discu)) do I
+            getindex.(values, (I,))
+        end
+    end
+    return nothing
+end
+
 function SciMLBase.PDETimeSeriesSolution(
         sol::SciMLBase.AbstractODESolution{T}, metadata::MOLMetadata
     ) where {T}
@@ -32,13 +52,15 @@ function SciMLBase.PDETimeSeriesSolution(
         # Reshape the solution to flat arrays, faster to do this eagerly.
         umap = mapreduce(vcat, dvs) do u
             let discu = discretespace.discvars[u]
-                solu = map(CartesianIndices(discu)) do I
-                    i = sym_to_index(discu[I], solved_unknowns)
-                    # Handle Observed
-                    if i !== nothing
-                        sol[i, :]
-                    else
-                        SciMLBase.observed(sol, safe_unwrap(discu[I]), :)
+                solu = array_observed_solution(sol, discu, ModelingToolkitBase.observed(odesys))
+                if solu === nothing
+                    solu = map(CartesianIndices(discu)) do I
+                        i = sym_to_index(discu[I], solved_unknowns)
+                        if i !== nothing
+                            sol[i, :]
+                        else
+                            SciMLBase.observed(sol, safe_unwrap(discu[I]), :)
+                        end
                     end
                 end
                 # Correct placement of time axis

--- a/test/Sol_Interface/array_observables.jl
+++ b/test/Sol_Interface/array_observables.jl
@@ -1,0 +1,61 @@
+using Test, MethodOfLines, ModelingToolkitBase, Symbolics, SymbolicUtils, SciMLBase
+using SciMLBase: symbolic_discretize
+
+struct RecordingArrayObserved{A, B}
+    arrays::A
+    bases::B
+    requests::Set{Any}
+end
+
+function (record::RecordingArrayObserved)(symbol, state, parameters, time)
+    symbol = Symbolics.unwrap(symbol)
+    push!(record.requests, symbol)
+    for (array, basis) in zip(record.arrays, record.bases)
+        if isequal(symbol, array)
+            return basis * state
+        elseif SymbolicUtils.iscall(symbol) && SymbolicUtils.operation(symbol) === getindex
+            args = SymbolicUtils.arguments(symbol)
+            isequal(first(args), array) || continue
+            indices = SymbolicUtils.unwrap_const.(args[2:end])
+            return (basis * state)[indices...]
+        end
+    end
+    error("unexpected observed request: $symbol")
+end
+
+@testset "array reconstruction queries are field-based" begin
+    for intervals in (5, 12)
+        @independent_variables t x
+        @variables v(..) w(..)
+        D = Differential(t)
+        @named pde = PDESystem(
+            [D(v(t, x)) ~ -v(t, x), D(w(x, t)) ~ -w(x, t)],
+            [v(0, x) ~ 1 + x, w(x, 0) ~ 2 - x],
+            [t ∈ (0.0, 0.2), x ∈ (0.0, 1.0)], [t, x], [v(t, x), w(x, t)]
+        )
+        source, _ = symbolic_discretize(pde, MOLFiniteDifference([x => 1 / intervals], t))
+        metadata = SymbolicUtils.getmetadata(source, ModelingToolkitBase.ProblemTypeCtx, nothing)
+        arrays = map([v(t, x), w(x, t)]) do field
+            scalar = Symbolics.unwrap(first(metadata.discretespace.discvars[field]))
+            first(SymbolicUtils.arguments(scalar))
+        end
+        grid = collect(range(0.0, 1.0; length = intervals + 1))
+        bases = [hcat(ones(length(grid)), grid), hcat(2ones(length(grid)), -grid)]
+        @variables reduced(t)[1:2]
+        @named rom = System(
+            [D(reduced) ~ -reduced], t, Symbolics.unwrap.(Symbolics.scalarize(reduced)), [];
+            observed = [array ~ basis * reduced for (array, basis) in zip(arrays, bases)]
+        )
+        record = RecordingArrayObserved(arrays, bases, Set{Any}())
+        rhs! = (du, u, p, t) -> (du .= -u)
+        f = ODEFunction{true}(rhs!; sys = complete(rom), observed = record)
+        prob = ODEProblem(f, ones(2), (0.0, 0.2))
+        times = [0.0, 0.1, 0.2]
+        states = [fill(exp(-time), 2) for time in times]
+        raw_solution = SciMLBase.build_solution(prob, nothing, times, states)
+        solution = SciMLBase.PDETimeSeriesSolution(raw_solution, metadata)
+        @test solution[v(t, x)] ≈ exp.(-times) * (1 .+ grid)'
+        @test solution[w(x, t)] ≈ (2 .- grid) * exp.(-times)'
+        @test length(record.requests) == 2
+    end
+end

--- a/test/Sol_Interface/solution_interface.jl
+++ b/test/Sol_Interface/solution_interface.jl
@@ -119,3 +119,5 @@ end
     @test (sol[x] == sol[y])
     @test (sol[y] isa StepRangeLen)
 end
+
+include("array_observables.jl")


### PR DESCRIPTION
PDE solution packaging currently requests a separate observed function for each spatial grid point. For array-based reduced systems, this reintroduces compilation that grows with the grid. Evaluate each matching array observation once per saved time and reshape its numeric values; retain the existing scalar fallback.

Companion to https://github.com/SciML/ModelOrderReduction.jl/pull/178. This fixes automatic PDE reconstruction as well as explicit whole-array evaluation. Matching and data movement still scale with the grid; the number of generated observation functions scales with the number of fields.

**Ignore this draft until reviewed by @ChrisRackauckas.**

### Verification

The same regression on unmodified master at https://github.com/SciML/MethodOfLines.jl/commit/b1d818f3 requested 12 and 26 distinct scalar observations for two fields on grids with 6 and 13 points:

```text
Expression: length(record.requests) == 2
Evaluated: 12 == 2
Evaluated: 26 == 2
array reconstruction queries are field-based | 4 passed  2 failed  6 total
```

The focused regression passes after the fix:

```text
array reconstruction queries are field-based | 6 passed  6 total
```

The complete relevant test group passes through `Pkg.test()`:

```sh
GROUP=Sol_Interface julia +1.12 --project -e 'using Pkg; Pkg.test()'
# Sol_Interface | 18 passed 18 total
# Testing MethodOfLines tests passed
```

After rebasing onto https://github.com/SciML/MethodOfLines.jl/commit/62f07c32, all validation above was repeated successfully: 18 solution-interface tests, 21 QA checks, and 106 MOR Core assertions with both local checkouts. Repository-wide Runic, typos, and `git diff --check` pass. QA passes through the package's standard runner:

```sh
GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'
# QA | 21 passed 21 total
# Testing MethodOfLines tests passed
``` The regression also checks reconstructed values with time as either the first or last field argument. No new dependency or public API is introduced. Documentation build is not applicable to this implementation-only change. The complete PDE test matrix and downgrade/LTS/prerelease jobs were not run locally.

An independently reproduced small-grid discretization failure is tracked at https://github.com/SciML/MethodOfLines.jl/issues/677. It occurs before solution reconstruction.

The existing Dependabot auto-merge workflow fails during startup before creating any jobs: https://github.com/SciML/MethodOfLines.jl/actions/runs/33965016166. The same startup failure occurred on the preceding upstream branch: https://github.com/SciML/MethodOfLines.jl/actions/runs/33950511092. This is separate from the validation checks reported above.

All **69 PR validation checks** passed for rebased commit https://github.com/SciML/MethodOfLines.jl/commit/7260461ff17ac1d22a3c6b06ff3b507c8e808186, including the complete declared CI test matrix, QA, documentation, downgrade, downstream, and benchmark checks. Test matrix: https://github.com/SciML/MethodOfLines.jl/actions/runs/33965016329; downstream: https://github.com/SciML/MethodOfLines.jl/actions/runs/33965016298.

### End-to-end MOR measurement

With both local branches, a real reduced `DAEProblem` and its PDE metadata (two POD/DEIM modes, three saved times) give these fresh-process measurements. Package loading, discretization, offline reduction, and problem construction precede the measured call:

| Spatial intervals | PDE reconstruction elapsed | Compilation |
|---:|---:|---:|
| 32 | 6.812 s | 6.802 s |
| 512 | 5.741 s | 5.725 s |

<details><summary>Measurement script</summary>

```julia
using ModelOrderReduction, MethodOfLines, ModelingToolkit, Symbolics, SymbolicUtils, SciMLBase
using SciMLBase: symbolic_discretize
function trial(intervals)
    @independent_variables t x
    @variables v(..)
    D = Differential(t)
    @named pde = PDESystem([D(v(t, x)) ~ -v(t, x) - v(t, x)^3], [v(0, x) ~ 1 + x],
        [t ∈ (0.0, 0.2), x ∈ (0.0, 1.0)], [t, x], [v(t, x)])
    source, _ = symbolic_discretize(pde, MOLFiniteDifference([x => 1 / intervals], t))
    metadata = SymbolicUtils.getmetadata(source, ModelingToolkit.ProblemTypeCtx, nothing)
    n = length(unknowns(source))
    snapshots = [sin(0.13i*j) + cos(0.07i*(j+1)) for i in 1:n, j in 1:8]
    rom = deim(source, snapshots, 2)
    prob = DAEProblem(rom, nothing, (0.0, 0.2); build_initializeprob=false)
    raw = SciMLBase.build_solution(prob, nothing, [0.0, 0.1, 0.2], [copy(prob.u0) for _ in 1:3])
    result = @timed SciMLBase.PDETimeSeriesSolution(raw, metadata)
    @assert size(result.value[v(t,x)]) == (3, intervals + 1)
    println((intervals=intervals, reconstruction_seconds=result.time,
        reconstruction_compile_seconds=result.compile_time))
end
trial(parse(Int, only(ARGS)))
```

Run in an environment with this MethodOfLines checkout and the MOR companion checkout, once per size: `julia --project pde-reconstruction-scaling.jl 32` and `julia --project pde-reconstruction-scaling.jl 512`. The actual runs used Julia 1.12.7 with `--check-bounds=yes --depwarn=yes --warn-overwrite=yes --startup-file=no`.

</details>

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session: 01a070dd-d97a-7180-9b71-095f2a5f5489). Transcript: `/home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T05-19-42-01a070dd-d97a-7180-9b71-095f2a5f5489.jsonl`.
