### PR TITLE
Test ModelingToolkitNeuralNets terms and fix the compiled ODE path

### DIFF
--- a/src/discretization/discretize_equations.jl
+++ b/src/discretization/discretize_equations.jl
@@ -2817,11 +2817,14 @@ function is_field_parameter_call(args)
         !is_array_parameter(args[1]) && is_array_parameter(args[2])
 end
 
+# Without ndims, promote_symtype returns Array{Real} and mtkcompile cannot
+# scalarize the term.
 array_map_callable(op, U::AbstractArray, θ) = map(ui -> op(ui, θ), U)
 Symbolics.@register_array_symbolic array_map_callable(
     op::Any, U::AbstractArray, θ::AbstractArray
 ) begin
     size = size(U)
+    ndims = ndims(U)
     eltype = Real
 end
 
@@ -2831,6 +2834,7 @@ Symbolics.@register_array_symbolic array_map_callable_getindex(
     op::Any, idx, U::AbstractArray, θ::AbstractArray
 ) begin
     size = size(U)
+    ndims = ndims(U)
     eltype = Real
 end
 

--- a/test/Discretization/equation_discretization.jl
+++ b/test/Discretization/equation_discretization.jl
@@ -150,14 +150,20 @@ function test_parameterized_heat(source; parameters = Any[], map_name = nothing)
         int_eq = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys_arr)))
         @test occursin(map_name, string(int_eq))
     end
+    function matches_exact(sol)
+        exact = [exp((1 - pi^2) * ti) * sinpi(xi) for ti in sol[t], xi in sol[x]]
+        return maximum(abs.(sol[u(t, x)] .- exact)) < 1.0e-2
+    end
     prob = discretize(pdesys, disc)
     @test prob isa SciMLBase.DAEProblem
     sol_arr = solve(prob)
     @test successful_retcode(sol_arr)
-    xdisc = sol_arr[x]
-    tdisc = sol_arr[t]
-    exact = [exp((1 - pi^2) * ti) * sinpi(xi) for ti in tdisc, xi in xdisc]
-    @test maximum(abs.(sol_arr[u(t, x)] .- exact)) < 1.0e-2
+    @test matches_exact(sol_arr)
+    # Compiled ODE path: mtkcompile scalarizes the registered calls.
+    prob_ode = ode_discretize(pdesys, disc)
+    sol_ode = solve(prob_ode, Rodas4(); reltol = 1.0e-10, abstol = 1.0e-10)
+    @test successful_retcode(sol_ode)
+    @test matches_exact(sol_ode)
     return nothing
 end
 

--- a/test/NeuralNets/Project.toml
+++ b/test/NeuralNets/Project.toml
@@ -1,0 +1,21 @@
+[deps]
+DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
+MethodOfLines = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+ModelingToolkitNeuralNets = "f162e290-f571-43a6-83d9-22ecc16da15f"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+DomainSets = "0.7, 0.8"
+ModelingToolkit = "11.39.1"
+ModelingToolkitNeuralNets = "2.8"
+OrdinaryDiffEq = "7"
+SciMLBase = "3.48"
+SymbolicUtils = "4.34.3"
+Symbolics = "7.38"
+Test = "1"
+julia = "1.10"

--- a/test/NeuralNets/neural_network_terms.jl
+++ b/test/NeuralNets/neural_network_terms.jl
@@ -1,0 +1,124 @@
+# ModelingToolkitNeuralNets networks in a PDE. A scalar field input `NN(u, θ)` maps over
+# the field slice on the DAE path and scalarizes on the compiled ODE path. A vector field
+# input `NN([u, v], θ)` falls back to pointwise equations.
+
+using MethodOfLines, ModelingToolkit, ModelingToolkitNeuralNets, OrdinaryDiffEq, DomainSets
+using SciMLBase
+using SciMLBase: successful_retcode
+using ModelingToolkit: get_eqs
+using Symbolics, SymbolicUtils
+using Test
+include(joinpath(@__DIR__, "..", "shared", "ode_discretize.jl"))
+
+# Helpers from test/Discretization/equation_discretization.jl.
+function isarrayeq(eq)
+    isarr(x) = let w = Symbolics.unwrap(x)
+        !(w isa AbstractArray) && SymbolicUtils.symtype(w) <: AbstractArray
+    end
+    return isarr(eq.lhs) || isarr(eq.rhs)
+end
+isinterioreq(eq) = occursin("Differential(t", string(eq))
+narrayeqs_interior(sys) = count(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys))
+function treesize(x)
+    x = Symbolics.unwrap(x)
+    SymbolicUtils.iscall(x) || return 1
+    return 1 + sum(treesize, SymbolicUtils.arguments(x); init = 0)
+end
+interior_treesize(sys) = sum(
+    treesize(eq.lhs) + treesize(eq.rhs) for eq in get_eqs(sys) if isinterioreq(eq)
+)
+
+@parameters t x
+@variables u(..) v(..)
+Dt = Differential(t)
+Dxx = Differential(x)^2
+domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
+disc = MOLFiniteDifference([x => 0.05], t)
+
+# Output scaled to O(1) so the term is not negligible. Weights are deterministic.
+NN, θ = SymbolicNeuralNetwork(;
+    n_input = 1, n_output = 1,
+    chain = multi_layer_feed_forward(1, 1; initial_scaling_factor = 1.0),
+    nn_p_name = :θ
+)
+
+heat_bcs(w) = [w(0, x) ~ sinpi(x), w(t, 0) ~ 0.0, w(t, 1) ~ 0.0]
+function heat_system(source; name, ps = [NN, θ])
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + source
+    return PDESystem(eq, heat_bcs(u), domains, [t, x], [u(t, x)], ps; name)
+end
+
+solve_tight(prob) = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.02)
+
+@testset "Scalar-input network on the DAE path" begin
+    pdesys = heat_system(NN(u(t, x), θ)[1]; name = :nn_heat)
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 1
+    interior = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys)))
+    @test occursin("array_map_callable_getindex(", string(interior))
+    # Interior expression size is independent of the grid.
+    sys_fine, _ = symbolic_discretize(pdesys, MOLFiniteDifference([x => 0.0125], t))
+    @test interior_treesize(sys_fine) == interior_treesize(sys)
+
+    prob = discretize(pdesys, disc)
+    @test prob isa SciMLBase.DAEProblem
+    sol = solve_tight(prob)
+    @test successful_retcode(sol)
+
+    # Vector input: pointwise reference.
+    pdesys_ref = heat_system(NN([u(t, x)], θ)[1]; name = :nn_heat_ref)
+    sys_ref, _ = symbolic_discretize(pdesys_ref, disc)
+    @test narrayeqs_interior(sys_ref) == 0
+    sol_ref = solve_tight(discretize(pdesys_ref, disc))
+    @test successful_retcode(sol_ref)
+    @test maximum(abs.(sol[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-8
+
+    # The term is not negligible.
+    pdesys_heat = heat_system(0; name = :heat, ps = [])
+    sol_heat = solve_tight(discretize(pdesys_heat, disc))
+    @test maximum(abs.(sol[u(t, x)] .- sol_heat[u(t, x)])) > 1.0e-3
+end
+
+@testset "Compiled ODE path scalarizes the network term" begin
+    pdesys = heat_system(NN(u(t, x), θ)[1]; name = :nn_heat_ode)
+    prob_ode = ode_discretize(pdesys, disc)
+    @test prob_ode isa SciMLBase.ODEProblem
+    sol_ode = solve_tight(prob_ode)
+    @test successful_retcode(sol_ode)
+    sol_dae = solve_tight(discretize(pdesys, disc))
+    @test maximum(abs.(sol_ode[u(t, x)] .- sol_dae[u(t, x)])) < 1.0e-6
+end
+
+@testset "One network shared by two fields" begin
+    eqs = [
+        Dt(u(t, x)) ~ Dxx(u(t, x)) + NN(u(t, x), θ)[1],
+        Dt(v(t, x)) ~ Dxx(v(t, x)) + NN(v(t, x), θ)[1],
+    ]
+    @named pdesys = PDESystem(
+        eqs, vcat(heat_bcs(u), heat_bcs(v)), domains, [t, x], [u(t, x), v(t, x)], [NN, θ]
+    )
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 2
+    sol = solve_tight(discretize(pdesys, disc))
+    @test successful_retcode(sol)
+    @test isapprox(sol[u(t, x)], sol[v(t, x)]; atol = 1.0e-8)
+end
+
+@testset "Vector field input falls back and solves" begin
+    NN2, θ2 = SymbolicNeuralNetwork(;
+        n_input = 2, n_output = 2,
+        chain = multi_layer_feed_forward(2, 2; initial_scaling_factor = 1.0),
+        nn_name = :NN2, nn_p_name = :θ2
+    )
+    eqs = [
+        Dt(u(t, x)) ~ Dxx(u(t, x)) + NN2([u(t, x), v(t, x)], θ2)[1],
+        Dt(v(t, x)) ~ Dxx(v(t, x)) + NN2([u(t, x), v(t, x)], θ2)[2],
+    ]
+    @named pdesys = PDESystem(
+        eqs, vcat(heat_bcs(u), heat_bcs(v)), domains, [t, x], [u(t, x), v(t, x)], [NN2, θ2]
+    )
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 0
+    sol = solve_tight(discretize(pdesys, disc))
+    @test successful_retcode(sol)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,6 +123,11 @@ run_tests(;
                 include(joinpath(@__DIR__, "Discretization", "problem_construction.jl"))
             end
         end,
+        # Own environment: ModelingToolkitNeuralNets pulls in Lux. Not part of "All".
+        "NeuralNets" => (;
+            env = joinpath(@__DIR__, "NeuralNets"),
+            body = joinpath(@__DIR__, "NeuralNets", "neural_network_terms.jl"),
+        ),
     ),
     qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
     all = FUNCTIONAL_GROUPS,

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -58,5 +58,8 @@ versions = ["lts", "1", "pre"]
 [Complex]
 versions = ["lts", "1", "pre"]
 
+[NeuralNets]
+versions = ["lts", "1", "pre"]
+
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
Follow-up to #675. The tests there used a stand-in for the MTKNN callable; this adds the real package and fixes a bug it turned up.

New `NeuralNets` test group with its own env (same setup as QA) so Lux only gets loaded there. Heat equation with a `SymbolicNeuralNetwork` term:

| | interior array eqs | |
|---|---:|---|
| `NN(u, θ)[1]` | 1 | matches the pointwise `NN([u], θ)[1]` form to 7e-12 |
| 21 → 81 grid points | 1 | interior stays at 54 nodes (pointwise 703 → 2923) |
| same `NN` in two fields | 2 | |
| `NN([u, v], θ)[i]` | 0 | falls back, still solves |

`mtkcompile` was failing on these terms. `@register_array_symbolic` with `size` but no `ndims` makes `promote_symtype` return `Array{Real}`, which blows up in alias elimination (`_numeric_or_arrnumeric_type`). Added `ndims` to both registrations. The parameterized heat tests in `Discretization` now also go through `mtkcompile` → `ODEProblem`; fails on master, passes here, agrees with the DAE path to 1e-11.

Still open: `NN([u, v], θ)` falls back, and the network is called per grid point rather than batched.