### PR TITLE
Stack vector field inputs and batch network calls in ArrayDiscretization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,12 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
+[weakdeps]
+ModelingToolkitNeuralNets = "f162e290-f571-43a6-83d9-22ecc16da15f"
+
+[extensions]
+MethodOfLinesModelingToolkitNeuralNetsExt = "ModelingToolkitNeuralNets"
+
 [compat]
 Combinatorics = "1"
 DiffEqBase = "7.18.1"
@@ -31,6 +37,7 @@ Latexify = "0.16"
 LinearAlgebra = "1"
 ModelingToolkit = "11.39.1"
 ModelingToolkitBase = "1.67"
+ModelingToolkitNeuralNets = "2.8"
 NonlinearSolve = "4"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqLowOrderRK = "2"

--- a/ext/MethodOfLinesModelingToolkitNeuralNetsExt.jl
+++ b/ext/MethodOfLinesModelingToolkitNeuralNetsExt.jl
@@ -1,0 +1,10 @@
+module MethodOfLinesModelingToolkitNeuralNetsExt
+
+using MethodOfLines: MethodOfLines
+using ModelingToolkitNeuralNets: ModelingToolkitNeuralNets
+using SymbolicUtils: BasicSymbolic
+
+# Lux networks take one column per sample, so a whole field slice is one call.
+MethodOfLines.batched_callable(f::BasicSymbolic) = ModelingToolkitNeuralNets.isneuralnetwork(f)
+
+end

--- a/src/discretization/discretize_equations.jl
+++ b/src/discretization/discretize_equations.jl
@@ -57,8 +57,10 @@
 # permuted and reshaped with singleton dimensions, matching `Idx`. A whole-domain
 # integrand with extra axes is a reduction (`array_integral_rules`), not a slice.
 #
-# Calls `f(u, θ)` map over the field slice without broadcasting `θ`.
-# `(f(u, θ))[i]` selects each point's output.
+# Calls `f(u, θ)` map over the field slice without broadcasting `θ`; `f([u, v], θ)`
+# stacks the slices along a leading axis (`array_stack`). `(f(...))[i]` selects each
+# point's output. Callables flagged by `batched_callable` receive the whole slice in
+# one call (Lux networks, through the ModelingToolkitNeuralNets extension).
 #
 # Unsupported patterns fall back to pointwise equations: callbacks,
 # a higher-dimensional field whose extra axes are free (not a boundary
@@ -2812,13 +2814,67 @@ is_array_valued(x) = SymbolicUtils.symtype(safe_unwrap(x)) <: AbstractArray
 is_symbolic_parameter(x) = ModelingToolkitBase.isparameter(safe_unwrap(x))
 is_array_parameter(x) = is_array_valued(x) && is_symbolic_parameter(x)
 
+is_field_slice(x) = is_array_valued(x) && !is_array_parameter(x)
+
 function is_field_parameter_call(args)
-    return length(args) == 2 && is_array_valued(args[1]) &&
-        !is_array_parameter(args[1]) && is_array_parameter(args[2])
+    return length(args) == 2 && is_field_slice(args[1]) && is_array_parameter(args[2])
 end
 
-# Without ndims, promote_symtype returns Array{Real} and mtkcompile cannot
-# scalarize the term.
+"""
+    batched_callable(f)
+
+Whether the symbolic callable parameter `f` evaluates all grid points in one call, one
+column per point, as Lux networks do. The default applies `f` point by point; the
+ModelingToolkitNeuralNets extension enables batching for its networks.
+"""
+batched_callable(@nospecialize(f)) = false
+
+# `[u, v]` inside a call arrives as `array_literal(shape, u, v)`.
+function is_array_literal_op(op)
+    return op isa Function && parentmodule(op) === SymbolicUtils &&
+        nameof(op) === :array_literal
+end
+is_array_literal(x) = (x = safe_unwrap(x); iscall(x) && is_array_literal_op(operation(x)))
+array_literal_elements(x) = arguments(safe_unwrap(x))[2:end]
+
+# The inputs of a call `f(input, θ)`: `θ` an array parameter kept whole, `input` a field
+# slice or `[u, v, ...]` stacked into a `(k, n...)` array. `nothing` for any other shape.
+function callable_inputs(args, ctx)
+    length(args) == 2 || return nothing
+    θ = arrayify(args[2], ctx)
+    is_array_parameter(θ) || return nothing
+    if is_array_literal(args[1])
+        slices = [arrayify(a, ctx) for a in array_literal_elements(args[1])]
+        isempty(slices) && return nothing
+        all(is_field_slice, slices) || return nothing
+        allequal(size(Symbolics.wrap(s)) for s in slices) || return nothing
+        X = foldl(array_stack, slices[2:end]; init = array_stack(slices[1]))
+        return X, θ, true
+    end
+    U = arrayify(args[1], ctx)
+    is_field_slice(U) || return nothing
+    return U, θ, false
+end
+
+# Registrations: `ndims` fixes the rank for `promote_symtype` (without it `mtkcompile`
+# cannot scalarize a rebuilt term), and the size rules must also hold for the shapes
+# `promote_shape` passes in.
+
+# Field slices stacked along a new leading axis: `(k, n...)` for `k` fields.
+array_stack(U::AbstractArray) = reshape(U, 1, size(U)...)
+Symbolics.@register_array_symbolic array_stack(U::AbstractArray) begin
+    size = (1, size(U)...)
+    ndims = ndims(U) + 1
+    eltype = Real
+end
+array_stack(X::AbstractArray, U::AbstractArray) = vcat(X, reshape(U, 1, size(U)...))
+Symbolics.@register_array_symbolic array_stack(X::AbstractArray, U::AbstractArray) begin
+    size = (last(size(X)[1]) + 1, size(U)...)
+    ndims = ndims(U) + 1
+    eltype = Real
+end
+
+# Point-by-point application.
 array_map_callable(op, U::AbstractArray, θ) = map(ui -> op(ui, θ), U)
 Symbolics.@register_array_symbolic array_map_callable(
     op::Any, U::AbstractArray, θ::AbstractArray
@@ -2838,6 +2894,48 @@ Symbolics.@register_array_symbolic array_map_callable_getindex(
     eltype = Real
 end
 
+# `X[:, I]` is one point's stacked inputs.
+stacked_points(X) = CartesianIndices(Base.tail(size(X)))
+array_map_callable_stacked(op, X::AbstractArray, θ) =
+    map(I -> op(X[:, I], θ), stacked_points(X))
+Symbolics.@register_array_symbolic array_map_callable_stacked(
+    op::Any, X::AbstractArray, θ::AbstractArray
+) begin
+    size = size(X)[2:end]
+    ndims = ndims(X) - 1
+    eltype = Real
+end
+array_map_callable_stacked_getindex(op, idx, X::AbstractArray, θ) =
+    map(I -> getindex(op(X[:, I], θ), idx), stacked_points(X))
+Symbolics.@register_array_symbolic array_map_callable_stacked_getindex(
+    op::Any, idx, X::AbstractArray, θ::AbstractArray
+) begin
+    size = size(X)[2:end]
+    ndims = ndims(X) - 1
+    eltype = Real
+end
+
+# Batched application: the callable sees every point at once and returns
+# `(outputs, n...)`.
+array_batch_callable_getindex(op, idx, U::AbstractArray, θ) =
+    collect(selectdim(op(reshape(U, 1, size(U)...), θ), 1, idx))
+Symbolics.@register_array_symbolic array_batch_callable_getindex(
+    op::Any, idx, U::AbstractArray, θ::AbstractArray
+) begin
+    size = size(U)
+    ndims = ndims(U)
+    eltype = Real
+end
+array_batch_callable_stacked_getindex(op, idx, X::AbstractArray, θ) =
+    collect(selectdim(op(X, θ), 1, idx))
+Symbolics.@register_array_symbolic array_batch_callable_stacked_getindex(
+    op::Any, idx, X::AbstractArray, θ::AbstractArray
+) begin
+    size = size(X)[2:end]
+    ndims = ndims(X) - 1
+    eltype = Real
+end
+
 function array_broadcast_call(op, newargs)
     is_field_parameter_call(newargs) &&
         return array_map_callable(op, newargs[1], newargs[2])
@@ -2850,8 +2948,7 @@ function array_broadcast_call(op, newargs)
     end
     any(is_array_valued, newargs) || return op(newargs...)
     # `[u]` has no slice form; broadcasting the literal would wrap each point.
-    op isa Function && parentmodule(op) === SymbolicUtils && nameof(op) === :array_literal &&
-        throw(ArrayFormFallback("unhandled array literal of a field"))
+    is_array_literal_op(op) && throw(ArrayFormFallback("unhandled array literal of a field"))
     return broadcast(op, newargs...)
 end
 
@@ -2905,7 +3002,9 @@ receives an array-valued argument. Time differentials are applied directly to th
 (array-valued) arguments; any spatial differential that survives the rules means the
 expression contains a scheme this path does not support, so fall back.
 
-Calls `f(u, θ)` map over the field slice. Indexed calls select each point's output.
+Calls `f(u, θ)` map over the field slice and `f([u, v], θ)` over the stacked slices;
+indexed calls select each point's output. Networks flagged by `batched_callable` are
+evaluated in one batched call.
 """
 function arrayify(expr, ctx)
     expr = safe_unwrap(expr)
@@ -2933,11 +3032,17 @@ function arrayify(expr, ctx)
             if iscall(inner)
                 iop = operation(inner)
                 if iop isa Function || is_symbolic_parameter(iop)
-                    iargs = [arrayify(a, ctx) for a in arguments(inner)]
-                    idx = arrayify(args[2], ctx)
-                    is_field_parameter_call(iargs) ||
+                    inputs = callable_inputs(arguments(inner), ctx)
+                    inputs === nothing &&
                         throw(ArrayFormFallback("unhandled callable getindex in $expr"))
-                    return array_map_callable_getindex(iop, idx, iargs[1], iargs[2])
+                    X, θ, stacked = inputs
+                    idx = arrayify(args[2], ctx)
+                    batched = batched_callable(iop)
+                    stacked && batched &&
+                        return array_batch_callable_stacked_getindex(iop, idx, X, θ)
+                    stacked && return array_map_callable_stacked_getindex(iop, idx, X, θ)
+                    batched && return array_batch_callable_getindex(iop, idx, X, θ)
+                    return array_map_callable_getindex(iop, idx, X, θ)
                 end
             end
         end
@@ -2945,6 +3050,12 @@ function arrayify(expr, ctx)
     if !(op isa Function) && !is_symbolic_parameter(op)
         # Symbolic operators (`Integral`, ...) cannot be broadcast over slices.
         throw(ArrayFormFallback("unhandled operation $op in $expr"))
+    end
+    if length(arguments(expr)) == 2 && is_array_literal(arguments(expr)[1])
+        inputs = callable_inputs(arguments(expr), ctx)
+        inputs === nothing && throw(ArrayFormFallback("unhandled array literal in $expr"))
+        X, θ, _ = inputs
+        return array_map_callable_stacked(op, X, θ)
     end
     return array_broadcast_call(op, [arrayify(a, ctx) for a in arguments(expr)])
 end

--- a/test/Discretization/equation_discretization.jl
+++ b/test/Discretization/equation_discretization.jl
@@ -210,7 +210,7 @@ end
     @test narrayeqs_interior(sys) == 0
 end
 
-@testset "Vector-input callable parameter falls back and solves" begin
+@testset "Vector-input callable parameter maps over the stacked field" begin
     @parameters t x
     @parameters θ[1:2] = [1.0, 0.0]
     @variables u(..)
@@ -226,7 +226,9 @@ end
 
     disc = MOLFiniteDifference([x => 0.05], t)
     sys, _ = symbolic_discretize(pdesys, disc)
-    @test narrayeqs_interior(sys) == 0
+    @test narrayeqs_interior(sys) == 1
+    int_eq = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys)))
+    @test occursin("array_map_callable_stacked_getindex(", string(int_eq))
     prob = discretize(pdesys, disc)
     sol = solve(prob)
     @test successful_retcode(sol)
@@ -234,6 +236,120 @@ end
     tdisc = sol[t]
     exact = [exp((1 - pi^2) * ti) * sinpi(xi) for ti in tdisc, xi in xdisc]
     @test maximum(abs.(sol[u(t, x)] .- exact)) < 1.0e-2
+end
+
+# Vector-input calls stack the field slices; the callable sees one point's values.
+vecfn_prod(x, θ) = θ[1] * x[1] * x[2]
+@register_symbolic vecfn_prod(x::AbstractVector, θ::AbstractVector)
+struct VectorPairWrapper end
+function (::VectorPairWrapper)(x::AbstractVector, θ::AbstractVector)
+    return [θ[1] * x[1] * x[2], -θ[1] * x[1] * x[2]]
+end
+const vecfn_pair = VectorPairWrapper()
+@parameters (vecfn_pair_parameter::typeof(vecfn_pair))(..)[1:2] =
+    vecfn_pair [tunable = false]
+
+@testset "Two-field reaction terms through stacked calls" begin
+    @parameters t x
+    @parameters θ[1:2] = [1.0, 0.0]
+    @variables u(..) v(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+    bcs = [
+        u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0,
+        v(0, x) ~ 0.5 * sinpi(x), v(t, 0) ~ 0.0, v(t, 1) ~ 0.0,
+    ]
+    domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
+    disc = MOLFiniteDifference([x => 0.05], t)
+    function system(ru, rv, ps, name)
+        eqs = [Dt(u(t, x)) ~ Dxx(u(t, x)) + ru, Dt(v(t, x)) ~ Dxx(v(t, x)) + rv]
+        return PDESystem(eqs, bcs, domains, [t, x], [u(t, x), v(t, x)], ps; name)
+    end
+    solve_tight(prob) = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.05)
+
+    uv = θ[1] * u(t, x) * v(t, x)
+    sol_ref = solve_tight(discretize(system(uv, -uv, [θ], :ref), disc))
+    scalar_uv = vecfn_prod([u(t, x), v(t, x)], θ)
+    pair_uv = vecfn_pair_parameter([u(t, x), v(t, x)], θ)
+    cases = (
+        (system(scalar_uv, -scalar_uv, [θ], :scalar), "array_map_callable_stacked("),
+        (
+            system(pair_uv[1], pair_uv[2], [vecfn_pair_parameter, θ], :pair),
+            "array_map_callable_stacked_getindex(",
+        ),
+    )
+    for (pdesys, fname) in cases
+        sys, _ = symbolic_discretize(pdesys, disc)
+        interior = filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys))
+        @test length(interior) == 2
+        @test all(eq -> occursin(fname, string(eq)), interior)
+        sol = solve_tight(discretize(pdesys, disc))
+        @test successful_retcode(sol)
+        @test maximum(abs.(sol[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-8
+        @test maximum(abs.(sol[v(t, x)] .- sol_ref[v(t, x)])) < 1.0e-8
+        sol_ode = solve(
+            ode_discretize(pdesys, disc), Rodas4();
+            abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.05
+        )
+        @test successful_retcode(sol_ode)
+        @test maximum(abs.(sol_ode[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-6
+    end
+end
+
+@testset "Stacked inputs need field slices of one shape" begin
+    @parameters t x
+    @parameters θ[1:2] = [1.0, 0.0]
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + vecfn_prod([u(t, x), 1.0], θ)
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [θ])
+
+    disc = MOLFiniteDifference([x => 0.05], t)
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 0
+    sol = solve(discretize(pdesys, disc))
+    @test successful_retcode(sol)
+    exact = [exp((1 - pi^2) * ti) * sinpi(xi) for ti in sol[t], xi in sol[x]]
+    @test maximum(abs.(sol[u(t, x)] .- exact)) < 1.0e-2
+end
+
+@testset "Stacked call on a 2D grid" begin
+    @parameters t x y
+    @parameters θ[1:2] = [1.0, 0.0]
+    @variables u(..) v(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
+    lap(w) = Dxx(w) + Dyy(w)
+    domains = [t ∈ Interval(0.0, 0.1), x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    bcs = [
+        u(0, x, y) ~ sinpi(x) * sinpi(y), v(0, x, y) ~ 0.5 * sinpi(x) * sinpi(y),
+        u(t, 0, y) ~ 0.0, u(t, 1, y) ~ 0.0, u(t, x, 0) ~ 0.0, u(t, x, 1) ~ 0.0,
+        v(t, 0, y) ~ 0.0, v(t, 1, y) ~ 0.0, v(t, x, 0) ~ 0.0, v(t, x, 1) ~ 0.0,
+    ]
+    disc = MOLFiniteDifference([x => 0.2, y => 0.2], t)
+    function system(ru, rv, ps, name)
+        eqs = [
+            Dt(u(t, x, y)) ~ lap(u(t, x, y)) + ru, Dt(v(t, x, y)) ~ lap(v(t, x, y)) + rv,
+        ]
+        return PDESystem(eqs, bcs, domains, [t, x, y], [u(t, x, y), v(t, x, y)], ps; name)
+    end
+    solve_tight(prob) = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.05)
+
+    uv = θ[1] * u(t, x, y) * v(t, x, y)
+    sol_ref = solve_tight(discretize(system(uv, -uv, [θ], :ref2d), disc))
+    pair_uv = vecfn_pair_parameter([u(t, x, y), v(t, x, y)], θ)
+    pdesys = system(pair_uv[1], pair_uv[2], [vecfn_pair_parameter, θ], :pair2d)
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 2
+    sol = solve_tight(discretize(pdesys, disc))
+    @test successful_retcode(sol)
+    @test maximum(abs.(sol[u(t, x, y)] .- sol_ref[u(t, x, y)])) < 1.0e-8
+    @test maximum(abs.(sol[v(t, x, y)] .- sol_ref[v(t, x, y)])) < 1.0e-8
 end
 
 @testset "1D diffusion, Neumann and Robin BCs" begin

--- a/test/NeuralNets/neural_network_terms.jl
+++ b/test/NeuralNets/neural_network_terms.jl
@@ -1,6 +1,7 @@
-# ModelingToolkitNeuralNets networks in a PDE. A scalar field input `NN(u, θ)` maps over
-# the field slice on the DAE path and scalarizes on the compiled ODE path. A vector field
-# input `NN([u, v], θ)` falls back to pointwise equations.
+# ModelingToolkitNeuralNets networks in a PDE. `NN(u, θ)` and `NN([u, v], θ)` stay in
+# array form on the DAE path and scalarize on the compiled ODE path. The extension
+# evaluates a network on the whole slice in one call; the same wrapper without the
+# network metadata is the point-by-point reference.
 
 using MethodOfLines, ModelingToolkit, ModelingToolkitNeuralNets, OrdinaryDiffEq, DomainSets
 using SciMLBase
@@ -42,6 +43,16 @@ NN, θ = SymbolicNeuralNetwork(;
     nn_p_name = :θ
 )
 
+nn_wrapper = ModelingToolkit.getdefault(NN)
+@parameters (NNpp::typeof(nn_wrapper))(..)[1:1] = nn_wrapper [tunable = false]
+NN2, θ2 = SymbolicNeuralNetwork(;
+    n_input = 2, n_output = 2,
+    chain = multi_layer_feed_forward(2, 2; initial_scaling_factor = 1.0),
+    nn_name = :NN2, nn_p_name = :θ2
+)
+nn2_wrapper = ModelingToolkit.getdefault(NN2)
+@parameters (NN2pp::typeof(nn2_wrapper))(..)[1:2] = nn2_wrapper [tunable = false]
+
 heat_bcs(w) = [w(0, x) ~ sinpi(x), w(t, 0) ~ 0.0, w(t, 1) ~ 0.0]
 function heat_system(source; name, ps = [NN, θ])
     eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + source
@@ -51,11 +62,13 @@ end
 solve_tight(prob) = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.02)
 
 @testset "Scalar-input network on the DAE path" begin
+    @test Base.get_extension(MethodOfLines, :MethodOfLinesModelingToolkitNeuralNetsExt) !==
+        nothing
     pdesys = heat_system(NN(u(t, x), θ)[1]; name = :nn_heat)
     sys, _ = symbolic_discretize(pdesys, disc)
     @test narrayeqs_interior(sys) == 1
     interior = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys)))
-    @test occursin("array_map_callable_getindex(", string(interior))
+    @test occursin("array_batch_callable_getindex(", string(interior))
     # Interior expression size is independent of the grid.
     sys_fine, _ = symbolic_discretize(pdesys, MOLFiniteDifference([x => 0.0125], t))
     @test interior_treesize(sys_fine) == interior_treesize(sys)
@@ -65,13 +78,24 @@ solve_tight(prob) = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.0
     sol = solve_tight(prob)
     @test successful_retcode(sol)
 
-    # Vector input: pointwise reference.
-    pdesys_ref = heat_system(NN([u(t, x)], θ)[1]; name = :nn_heat_ref)
-    sys_ref, _ = symbolic_discretize(pdesys_ref, disc)
-    @test narrayeqs_interior(sys_ref) == 0
-    sol_ref = solve_tight(discretize(pdesys_ref, disc))
-    @test successful_retcode(sol_ref)
-    @test maximum(abs.(sol[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-8
+    # Point-by-point reference: the same network without the metadata.
+    pdesys_pp = heat_system(NNpp(u(t, x), θ)[1]; name = :nn_heat_pp, ps = [NNpp, θ])
+    sys_pp, _ = symbolic_discretize(pdesys_pp, disc)
+    interior_pp = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys_pp)))
+    @test occursin("array_map_callable_getindex(", string(interior_pp))
+    sol_pp = solve_tight(discretize(pdesys_pp, disc))
+    @test successful_retcode(sol_pp)
+    @test maximum(abs.(sol[u(t, x)] .- sol_pp[u(t, x)])) < 1.0e-8
+
+    # A one-element vector input is a stack of one slice.
+    pdesys_vec = heat_system(NN([u(t, x)], θ)[1]; name = :nn_heat_vec)
+    sys_vec, _ = symbolic_discretize(pdesys_vec, disc)
+    @test narrayeqs_interior(sys_vec) == 1
+    interior_vec = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys_vec)))
+    @test occursin("array_batch_callable_stacked_getindex(", string(interior_vec))
+    sol_vec = solve_tight(discretize(pdesys_vec, disc))
+    @test successful_retcode(sol_vec)
+    @test maximum(abs.(sol[u(t, x)] .- sol_vec[u(t, x)])) < 1.0e-8
 
     # The term is not negligible.
     pdesys_heat = heat_system(0; name = :heat, ps = [])
@@ -104,21 +128,80 @@ end
     @test isapprox(sol[u(t, x)], sol[v(t, x)]; atol = 1.0e-8)
 end
 
-@testset "Vector field input falls back and solves" begin
-    NN2, θ2 = SymbolicNeuralNetwork(;
-        n_input = 2, n_output = 2,
-        chain = multi_layer_feed_forward(2, 2; initial_scaling_factor = 1.0),
-        nn_name = :NN2, nn_p_name = :θ2
-    )
-    eqs = [
-        Dt(u(t, x)) ~ Dxx(u(t, x)) + NN2([u(t, x), v(t, x)], θ2)[1],
-        Dt(v(t, x)) ~ Dxx(v(t, x)) + NN2([u(t, x), v(t, x)], θ2)[2],
-    ]
-    @named pdesys = PDESystem(
-        eqs, vcat(heat_bcs(u), heat_bcs(v)), domains, [t, x], [u(t, x), v(t, x)], [NN2, θ2]
-    )
+@testset "Vector field input is stacked and batched" begin
+    function two_field(net, ps, name)
+        uv = net([u(t, x), v(t, x)], ps[end])
+        eqs = [Dt(u(t, x)) ~ Dxx(u(t, x)) + uv[1], Dt(v(t, x)) ~ Dxx(v(t, x)) + uv[2]]
+        return PDESystem(
+            eqs, vcat(heat_bcs(u), heat_bcs(v)), domains, [t, x], [u(t, x), v(t, x)], ps;
+            name
+        )
+    end
+    pdesys = two_field(NN2, [NN2, θ2], :nn_two)
     sys, _ = symbolic_discretize(pdesys, disc)
-    @test narrayeqs_interior(sys) == 0
+    interior = filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys))
+    @test length(interior) == 2
+    @test all(eq -> occursin("array_batch_callable_stacked_getindex(", string(eq)), interior)
     sol = solve_tight(discretize(pdesys, disc))
+    @test successful_retcode(sol)
+
+    pdesys_pp = two_field(NN2pp, [NN2pp, θ2], :nn_two_pp)
+    sys_pp, _ = symbolic_discretize(pdesys_pp, disc)
+    interior_pp = filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys_pp))
+    @test all(eq -> occursin("array_map_callable_stacked_getindex(", string(eq)), interior_pp)
+    sol_pp = solve_tight(discretize(pdesys_pp, disc))
+    @test successful_retcode(sol_pp)
+    @test maximum(abs.(sol[u(t, x)] .- sol_pp[u(t, x)])) < 1.0e-8
+    @test maximum(abs.(sol[v(t, x)] .- sol_pp[v(t, x)])) < 1.0e-8
+
+    sol_ode = solve_tight(ode_discretize(pdesys, disc))
+    @test successful_retcode(sol_ode)
+    @test maximum(abs.(sol_ode[u(t, x)] .- sol[u(t, x)])) < 1.0e-6
+end
+
+@testset "Brusselator with a network term" begin
+    α = 0.1
+    uv = NN2([u(t, x), v(t, x)], θ2)
+    eqs = [
+        Dt(u(t, x)) ~ 1 + u(t, x)^2 * v(t, x) - 4.4 * u(t, x) + α * Dxx(u(t, x)) + uv[1],
+        Dt(v(t, x)) ~ 3.4 * u(t, x) - u(t, x)^2 * v(t, x) + α * Dxx(v(t, x)) + uv[2],
+    ]
+    bcs = [
+        u(0, x) ~ 22 * (x * (1 - x))^(3 / 2), v(0, x) ~ 27 * (x * (1 - x))^(3 / 2),
+        u(t, 0) ~ u(t, 1), v(t, 0) ~ v(t, 1),
+    ]
+    bruss_domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0)]
+    @named bruss = PDESystem(eqs, bcs, bruss_domains, [t, x], [u(t, x), v(t, x)], [NN2, θ2])
+    # The periodic seam points stay pointwise; their number does not grow with the grid.
+    nscalar_interior(sys) = count(!isarrayeq, filter(isinterioreq, get_eqs(sys)))
+    sys, _ = symbolic_discretize(bruss, disc)
+    @test narrayeqs_interior(sys) == 2
+    sys_fine, _ = symbolic_discretize(bruss, MOLFiniteDifference([x => 0.025], t))
+    @test nscalar_interior(sys_fine) == nscalar_interior(sys)
+    sol = solve(discretize(bruss, disc); saveat = 0.1)
+    @test successful_retcode(sol)
+end
+
+@testset "Stacked network input on a 2D grid" begin
+    @parameters y
+    Dyy = Differential(y)^2
+    uv = NN2([u(t, x, y), v(t, x, y)], θ2)
+    eqs = [
+        Dt(u(t, x, y)) ~ Dxx(u(t, x, y)) + Dyy(u(t, x, y)) + uv[1],
+        Dt(v(t, x, y)) ~ Dxx(v(t, x, y)) + Dyy(v(t, x, y)) + uv[2],
+    ]
+    bcs = [
+        u(0, x, y) ~ sinpi(x) * sinpi(y), v(0, x, y) ~ sinpi(x) * sinpi(y),
+        u(t, 0, y) ~ 0.0, u(t, 1, y) ~ 0.0, u(t, x, 0) ~ 0.0, u(t, x, 1) ~ 0.0,
+        v(t, 0, y) ~ 0.0, v(t, 1, y) ~ 0.0, v(t, x, 0) ~ 0.0, v(t, x, 1) ~ 0.0,
+    ]
+    domains2 = [t ∈ Interval(0.0, 0.05), x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)]
+    @named pdesys = PDESystem(
+        eqs, bcs, domains2, [t, x, y], [u(t, x, y), v(t, x, y)], [NN2, θ2]
+    )
+    disc2 = MOLFiniteDifference([x => 0.2, y => 0.2], t)
+    sys, _ = symbolic_discretize(pdesys, disc2)
+    @test narrayeqs_interior(sys) == 2
+    sol = solve(discretize(pdesys, disc2); saveat = 0.05)
     @test successful_retcode(sol)
 end


### PR DESCRIPTION
Vector field inputs `f([u, v], θ)` and `f([u, v], θ)[i]` now stay in array form. The slices are stacked along a leading axis (`array_stack`, `(k, n...)`), so the interior is still one array equation per field and the expression size does not depend on the grid. Any callable works; by default it is applied point by point on `X[:, I]`.

Networks from ModelingToolkitNeuralNets are evaluated in one batched call instead. A small package extension sets `batched_callable` from the public `isneuralnetwork` accessor; the runtime passes the whole `(k, n...)` array to the network (Lux takes one column per sample) and selects output row `i`. `NN(u, θ)` is batched too; results agree with the previous point-by-point evaluation to 1e-8 in the tests, so roundoff-level differences are possible.

| | interior array eqs | |
|---|---:|---|
| `vecfn([u, v], θ)`, registered scalar function | 2 | matches the symbolic `θ[1] u v` form to 1e-8 on the DAE path, 1e-6 through `mtkcompile` |
| `f([u, v], θ)[i]`, callable parameter | 2 | same numbers, point by point |
| `NN([u, v], θ)[i]` | 2 | batched; matches the same network without the metadata (point by point) to 1e-8 |
| `NN([u], θ)[1]` | 1 | stack of one slice |
| Brusselator with `NN([u, v], θ)`, periodic | 2 | the seam points stay pointwise, their count is grid independent |
| 2D grid, both callables | 2 | |
| `f([u, 1.0], θ)` | 0 | falls back: inputs must be slices of one shape |

RHS evaluation, batched vs point by point, same network:

| grid points | single field | two fields |
|---:|---:|---:|
| 101 | 21 μs vs 84 μs | 38 μs vs 181 μs |
| 1001 | 491 μs vs 1357 μs | 1013 μs vs 2170 μs |

Not covered: scalar inputs mixed with slices (`[u, t]`), and `θ` in any position other than second. Next: a Brusselator UDE section in the tutorial.