### PR TITLE
Stack scalar inputs with field slices in ArrayDiscretization

### DIFF
--- a/src/discretization/discretize_equations.jl
+++ b/src/discretization/discretize_equations.jl
@@ -58,7 +58,8 @@
 # integrand with extra axes is a reduction (`array_integral_rules`), not a slice.
 #
 # Calls `f(u, θ)` map over the field slice without broadcasting `θ`; `f([u, v], θ)`
-# stacks the slices along a leading axis (`array_stack`). `(f(...))[i]` selects each
+# stacks the slices along a leading axis (`array_stack`), scalars and lower-dimensional
+# arrays in the literal broadcast onto the slice first. `(f(...))[i]` selects each
 # point's output. Callables flagged by `batched_callable` receive the whole slice in
 # one call (Lux networks, through the ModelingToolkitNeuralNets extension).
 #
@@ -2837,18 +2838,36 @@ end
 is_array_literal(x) = (x = safe_unwrap(x); iscall(x) && is_array_literal_op(operation(x)))
 array_literal_elements(x) = arguments(safe_unwrap(x))[2:end]
 
+# Whether `x` broadcasts onto an array of size `shape`: a scalar, or an array whose
+# dimensions are 1 or equal to the target's.
+function array_broadcasts_onto(x, shape)
+    is_array_valued(x) || return true
+    sz = size(Symbolics.wrap(x))
+    return length(sz) <= length(shape) &&
+        all(i -> sz[i] == 1 || sz[i] == shape[i], eachindex(sz))
+end
+
 # The inputs of a call `f(input, θ)`: `θ` an array parameter kept whole, `input` a field
-# slice or `[u, v, ...]` stacked into a `(k, n...)` array. `nothing` for any other shape.
+# slice or `[u, v, ...]` stacked into a `(k, n...)` array. Scalars (`t`, parameters,
+# time-only dependents, numbers) and lower-dimensional arrays in the literal are
+# broadcast onto the core slice; array parameters are not. `nothing` for any other shape.
 function callable_inputs(args, ctx)
     length(args) == 2 || return nothing
     θ = arrayify(args[2], ctx)
     is_array_parameter(θ) || return nothing
     if is_array_literal(args[1])
-        slices = [arrayify(a, ctx) for a in array_literal_elements(args[1])]
+        elements = [arrayify(a, ctx) for a in array_literal_elements(args[1])]
+        any(is_array_parameter, elements) && return nothing
+        slices = filter(is_field_slice, elements)
         isempty(slices) && return nothing
-        all(is_field_slice, slices) || return nothing
-        allequal(size(Symbolics.wrap(s)) for s in slices) || return nothing
-        X = foldl(array_stack, slices[2:end]; init = array_stack(slices[1]))
+        donor = argmax(e -> length(Symbolics.wrap(e)), slices)
+        shape = size(Symbolics.wrap(donor))
+        all(e -> array_broadcasts_onto(e, shape), elements) || return nothing
+        stacked = map(elements) do e
+            is_field_slice(e) && size(Symbolics.wrap(e)) == shape && return e
+            return array_broadcast_onto(e, donor)
+        end
+        X = foldl(array_stack, stacked[2:end]; init = array_stack(stacked[1]))
         return X, θ, true
     end
     U = arrayify(args[1], ctx)
@@ -3002,9 +3021,9 @@ receives an array-valued argument. Time differentials are applied directly to th
 (array-valued) arguments; any spatial differential that survives the rules means the
 expression contains a scheme this path does not support, so fall back.
 
-Calls `f(u, θ)` map over the field slice and `f([u, v], θ)` over the stacked slices;
-indexed calls select each point's output. Networks flagged by `batched_callable` are
-evaluated in one batched call.
+Calls `f(u, θ)` map over the field slice and `f([u, v], θ)` over the stacked slices,
+scalars in the literal broadcast onto the slice; indexed calls select each point's
+output. Networks flagged by `batched_callable` are evaluated in one batched call.
 """
 function arrayify(expr, ctx)
     expr = safe_unwrap(expr)

--- a/test/Discretization/equation_discretization.jl
+++ b/test/Discretization/equation_discretization.jl
@@ -241,6 +241,8 @@ end
 # Vector-input calls stack the field slices; the callable sees one point's values.
 vecfn_prod(x, θ) = θ[1] * x[1] * x[2]
 @register_symbolic vecfn_prod(x::AbstractVector, θ::AbstractVector)
+vecfn_nested(x, θ) = θ[1] * x[1] * x[2][1]
+@register_symbolic vecfn_nested(x::AbstractVector, θ::AbstractVector)
 struct VectorPairWrapper end
 function (::VectorPairWrapper)(x::AbstractVector, θ::AbstractVector)
     return [θ[1] * x[1] * x[2], -θ[1] * x[1] * x[2]]
@@ -296,14 +298,73 @@ const vecfn_pair = VectorPairWrapper()
     end
 end
 
-@testset "Stacked inputs need field slices of one shape" begin
+@testset "Scalars stack with the field slice" begin
+    @parameters t x
+    @parameters θ[1:2] = [1.0, 0.0]
+    @parameters k = 0.5
+    @variables u(..) S(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
+    disc = MOLFiniteDifference([x => 0.05], t)
+    solve_tight(prob) = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.05)
+    function system(reaction, ps, name; eqs = Equation[], bcs = bcs, dvs = [u(t, x)])
+        eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + reaction
+        return PDESystem(vcat(eq, eqs), bcs, domains, [t, x], dvs, ps; name)
+    end
+    # (stacked input, its symbolic form, parameters)
+    cases = (
+        (x, x, [θ]), (t, t, [θ]), (k, k, [k, θ]), (1.0, 1.0, [θ]),
+    )
+    for (input, factor, ps) in cases
+        ref = system(θ[1] * u(t, x) * factor, ps, :ref)
+        stacked = system(vecfn_prod([u(t, x), input], θ), ps, :stacked)
+        sys, _ = symbolic_discretize(stacked, disc)
+        @test narrayeqs_interior(sys) == 1
+        int_eq = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys)))
+        @test occursin("array_map_callable_stacked(", string(int_eq))
+        sol_ref = solve_tight(discretize(ref, disc))
+        sol = solve_tight(discretize(stacked, disc))
+        @test successful_retcode(sol)
+        @test maximum(abs.(sol[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-8
+    end
+    # compiled ODE path
+    stacked = system(vecfn_prod([u(t, x), t], θ), [θ], :stacked_ode)
+    ref = system(θ[1] * u(t, x) * t, [θ], :ref_ode)
+    sol_ode = solve(
+        ode_discretize(stacked, disc), Rodas4();
+        abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.05
+    )
+    sol_ref = solve_tight(discretize(ref, disc))
+    @test successful_retcode(sol_ode)
+    @test maximum(abs.(sol_ode[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-6
+    # a time-only dependent is a scalar too
+    ode = [Dt(S(t)) ~ -S(t)]
+    bcs_S = vcat(bcs, S(0) ~ 1.0)
+    ref = system(
+        θ[1] * u(t, x) * S(t), [θ], :ref_S; eqs = ode, bcs = bcs_S, dvs = [u(t, x), S(t)]
+    )
+    stacked = system(
+        vecfn_prod([u(t, x), S(t)], θ), [θ], :stacked_S; eqs = ode, bcs = bcs_S,
+        dvs = [u(t, x), S(t)]
+    )
+    sys, _ = symbolic_discretize(stacked, disc)
+    @test narrayeqs_interior(sys) == 1
+    sol_ref = solve_tight(discretize(ref, disc))
+    sol = solve_tight(discretize(stacked, disc))
+    @test successful_retcode(sol)
+    @test maximum(abs.(sol[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-8
+end
+
+@testset "Array parameters do not stack" begin
     @parameters t x
     @parameters θ[1:2] = [1.0, 0.0]
     @variables u(..)
     Dt = Differential(t)
     Dxx = Differential(x)^2
 
-    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + vecfn_prod([u(t, x), 1.0], θ)
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + vecfn_nested([u(t, x), θ], θ)
     bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
     domains = [t ∈ Interval(0.0, 0.2), x ∈ Interval(0.0, 1.0)]
     @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)], [θ])
@@ -350,6 +411,32 @@ end
     @test successful_retcode(sol)
     @test maximum(abs.(sol[u(t, x, y)] .- sol_ref[u(t, x, y)])) < 1.0e-8
     @test maximum(abs.(sol[v(t, x, y)] .- sol_ref[v(t, x, y)])) < 1.0e-8
+
+    # The coordinate arrays broadcast onto the 2D slice.
+    ux = θ[1] * u(t, x, y) * x
+    sol_ref = solve_tight(discretize(system(ux, -ux, [θ], :ref2d_x), disc))
+    stacked_x = vecfn_prod([u(t, x, y), x], θ)
+    pdesys = system(stacked_x, -stacked_x, [θ], :stacked2d_x)
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 2
+    sol = solve_tight(discretize(pdesys, disc))
+    @test successful_retcode(sol)
+    @test maximum(abs.(sol[u(t, x, y)] .- sol_ref[u(t, x, y)])) < 1.0e-8
+
+    # So does a lower-dimensional field.
+    @variables w(..)
+    bcs_w = vcat(bcs[1:1], bcs[3:6], w(0, x) ~ sinpi(x), w(t, 0) ~ 0.0, w(t, 1) ~ 0.0)
+    function system_w(reaction, name)
+        eqs = [Dt(u(t, x, y)) ~ lap(u(t, x, y)) + reaction, Dt(w(t, x)) ~ Dxx(w(t, x))]
+        return PDESystem(eqs, bcs_w, domains, [t, x, y], [u(t, x, y), w(t, x)], [θ]; name)
+    end
+    sol_ref = solve_tight(discretize(system_w(θ[1] * u(t, x, y) * w(t, x), :ref2d_w), disc))
+    pdesys = system_w(vecfn_prod([u(t, x, y), w(t, x)], θ), :stacked2d_w)
+    sys, _ = symbolic_discretize(pdesys, disc)
+    @test narrayeqs_interior(sys) == 2
+    sol = solve_tight(discretize(pdesys, disc))
+    @test successful_retcode(sol)
+    @test maximum(abs.(sol[u(t, x, y)] .- sol_ref[u(t, x, y)])) < 1.0e-8
 end
 
 @testset "1D diffusion, Neumann and Robin BCs" begin

--- a/test/NeuralNets/neural_network_terms.jl
+++ b/test/NeuralNets/neural_network_terms.jl
@@ -159,6 +159,24 @@ end
     @test maximum(abs.(sol_ode[u(t, x)] .- sol[u(t, x)])) < 1.0e-6
 end
 
+@testset "Scalar inputs stack with the field" begin
+    for extra in (x, t)
+        function one_field(net, ps, name)
+            eq = Dt(u(t, x)) ~ Dxx(u(t, x)) + net([u(t, x), extra], ps[end])[1]
+            return PDESystem(eq, heat_bcs(u), domains, [t, x], [u(t, x)], ps; name)
+        end
+        pdesys = one_field(NN2, [NN2, θ2], :nn_scalar)
+        sys, _ = symbolic_discretize(pdesys, disc)
+        @test narrayeqs_interior(sys) == 1
+        interior = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys)))
+        @test occursin("array_batch_callable_stacked_getindex(", string(interior))
+        sol = solve_tight(discretize(pdesys, disc))
+        @test successful_retcode(sol)
+        sol_pp = solve_tight(discretize(one_field(NN2pp, [NN2pp, θ2], :nn_scalar_pp), disc))
+        @test maximum(abs.(sol[u(t, x)] .- sol_pp[u(t, x)])) < 1.0e-8
+    end
+end
+
 @testset "Brusselator with a network term" begin
     α = 0.1
     uv = NN2([u(t, x), v(t, x)], θ2)


### PR DESCRIPTION
Follow-up to #680. A vector input to a callable can now mix field slices with scalars: `f([u, t], θ)`, `f([u, k], θ)` with a scalar parameter, `f([u, S(t)], θ)` with a time-only dependent, or a number. Scalars and lower-dimensional arrays (the 2D coordinate arrays, a 1D field in a 2D equation) are broadcast onto the core slice with `array_broadcast_onto`, already used for scalar equation sides, before stacking. `f([u, x], θ)` already worked, since `x` arrayifies to the coordinate vector; it is now covered by tests.

| | interior array eqs | |
|---|---:|---|
| `f([u, x], θ)`, `f([u, t], θ)`, `f([u, k], θ)`, `f([u, 1.0], θ)` | 1 | each matches its symbolic form (`θ[1] u x`, ...) to 1e-8 |
| `f([u, t], θ)` through `mtkcompile` | scalarized | 1e-6 |
| `f([u, S(t)], θ)`, `S` a time-only dependent | 1 | 1e-8 |
| 2D, `f([u, x], θ)` and `f([u, w], θ)` with `w(t, x)` | 2 | `(nx, 1)` broadcast onto `(nx, ny)`, 1e-8 |
| `NN([u, x], θ)[1]`, `NN([u, t], θ)[1]` | 1 | batched; matches the point-by-point evaluation to 1e-8 |
| `f([u, θ], θ)`, array parameter in the literal | 0 | falls back |

No new functions: the existing `array_broadcast_onto` and `array_stack` are reused. An input with no field slice at all, such as `f([t], θ)`, still falls back.