### PR TITLE
Test callable diffusion coefficients

### DIFF
--- a/test/Discretization/equation_discretization.jl
+++ b/test/Discretization/equation_discretization.jl
@@ -988,6 +988,65 @@ end
     @test narrayeqs_interior(sys_arr) == 1
 end
 
+# A callable diffusion coefficient stays in array form: inside `Dx(a Dx(u))` it is
+# evaluated on the half-point slices, in front of `Dxx(u)` on the interior.
+coef_linear(u, θ) = 1 + θ[1] * u
+@register_symbolic coef_linear(u, θ::AbstractVector)
+
+@testset "Callable diffusion coefficients" begin
+    @parameters t x
+    @parameters θ[1:2] = [0.5, 0.0]
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dxx = Differential(x)^2
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.1), x ∈ Interval(0.0, 1.0)]
+    disc = MOLFiniteDifference([x => 0.05], t)
+    solve_tight(prob) = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.02)
+    function system(rhs, name)
+        return PDESystem(Dt(u(t, x)) ~ rhs, bcs, domains, [t, x], [u(t, x)], [θ]; name)
+    end
+    nscalar_interior(sys) = count(!isarrayeq, filter(isinterioreq, get_eqs(sys)))
+
+    a_call = coef_linear(u(t, x), θ)
+    a_sym = 1 + θ[1] * u(t, x)
+    ax_call = 1 + vecfn_prod([u(t, x), x], θ)
+    ax_sym = 1 + θ[1] * u(t, x) * x
+    # (callable form, symbolic form, function in the interior equation)
+    cases = (
+        (Dx(a_call * Dx(u(t, x))), Dx(a_sym * Dx(u(t, x))), "array_map_callable("),
+        (a_call * Dxx(u(t, x)), a_sym * Dxx(u(t, x)), "array_map_callable("),
+        (
+            Dx(ax_call * Dx(u(t, x))), Dx(ax_sym * Dx(u(t, x))),
+            "array_map_callable_stacked(",
+        ),
+    )
+    for (rhs_call, rhs_sym, fname) in cases
+        pdesys = system(rhs_call, :callable)
+        sys, _ = symbolic_discretize(pdesys, disc)
+        @test narrayeqs_interior(sys) == 1
+        int_eq = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys)))
+        @test occursin(fname, string(int_eq))
+        # Frame points stay pointwise; their count does not grow with the grid.
+        sys_fine, _ = symbolic_discretize(pdesys, MOLFiniteDifference([x => 0.025], t))
+        @test nscalar_interior(sys_fine) == nscalar_interior(sys)
+        sol = solve_tight(discretize(pdesys, disc))
+        sol_ref = solve_tight(discretize(system(rhs_sym, :symbolic), disc))
+        @test successful_retcode(sol)
+        @test maximum(abs.(sol[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-8
+    end
+    # compiled ODE path
+    pdesys = system(Dx(a_call * Dx(u(t, x))), :callable_ode)
+    sol_ode = solve(
+        ode_discretize(pdesys, disc), Rodas4();
+        abstol = 1.0e-10, reltol = 1.0e-10, saveat = 0.02
+    )
+    sol_ref = solve_tight(discretize(system(Dx(a_sym * Dx(u(t, x))), :symbolic_ode), disc))
+    @test successful_retcode(sol_ode)
+    @test maximum(abs.(sol_ode[u(t, x)] .- sol_ref[u(t, x)])) < 1.0e-6
+end
+
 @testset "1D spherical laplacian" begin
     # Cardinalization rewrites Dt(u) ~ Dr(r^2*Dr(u))/r^2 with a Mul numerator, the shape
     # the pointwise path discretizes through the nonlinear laplacian rules: r^2 enters at

--- a/test/NeuralNets/neural_network_terms.jl
+++ b/test/NeuralNets/neural_network_terms.jl
@@ -223,3 +223,55 @@ end
     sol = solve(discretize(pdesys, disc2); saveat = 0.05)
     @test successful_retcode(sol)
 end
+
+@testset "Network diffusion coefficients" begin
+    Dx = Differential(x)
+    # Small outputs keep the diffusivity `1 + NN` positive.
+    NNc, θc = SymbolicNeuralNetwork(;
+        n_input = 1, n_output = 1,
+        chain = multi_layer_feed_forward(1, 1; initial_scaling_factor = 0.1),
+        nn_name = :NNc, nn_p_name = :θc
+    )
+    nnc_wrapper = ModelingToolkit.getdefault(NNc)
+    @parameters (NNcpp::typeof(nnc_wrapper))(..)[1:1] = nnc_wrapper [tunable = false]
+    NNx, θx = SymbolicNeuralNetwork(;
+        n_input = 2, n_output = 1,
+        chain = multi_layer_feed_forward(2, 1; initial_scaling_factor = 0.1),
+        nn_name = :NNx, nn_p_name = :θx
+    )
+    nnx_wrapper = ModelingToolkit.getdefault(NNx)
+    @parameters (NNxpp::typeof(nnx_wrapper))(..)[1:1] = nnx_wrapper [tunable = false]
+    function system(rhs, ps, name)
+        return PDESystem(
+            Dt(u(t, x)) ~ rhs, heat_bcs(u), domains, [t, x], [u(t, x)], ps; name
+        )
+    end
+    # (right-hand side for a network, batched network, point-by-point twin, parameters,
+    # function in the interior equation)
+    cases = (
+        (
+            net -> Dx((1 + net(u(t, x), θc)[1]) * Dx(u(t, x))), NNc, NNcpp, θc,
+            "array_batch_callable_getindex(",
+        ),
+        (
+            net -> Dx((1 + net([u(t, x), x], θx)[1]) * Dx(u(t, x))), NNx, NNxpp, θx,
+            "array_batch_callable_stacked_getindex(",
+        ),
+        (
+            net -> (1 + net([u(t, x), x], θx)[1]) * Dxx(u(t, x)), NNx, NNxpp, θx,
+            "array_batch_callable_stacked_getindex(",
+        ),
+    )
+    for (rhs, net, netpp, ps, fname) in cases
+        pdesys = system(rhs(net), [net, ps], :nn_coefficient)
+        sys, _ = symbolic_discretize(pdesys, disc)
+        @test narrayeqs_interior(sys) == 1
+        int_eq = only(filter(eq -> isinterioreq(eq) && isarrayeq(eq), get_eqs(sys)))
+        @test occursin(fname, string(int_eq))
+        sol = solve_tight(discretize(pdesys, disc))
+        @test successful_retcode(sol)
+        pdesys_pp = system(rhs(netpp), [netpp, ps], :nn_coefficient_pp)
+        sol_pp = solve_tight(discretize(pdesys_pp, disc))
+        @test maximum(abs.(sol[u(t, x)] .- sol_pp[u(t, x)])) < 1.0e-8
+    end
+end


### PR DESCRIPTION
Tests only. A registered function or a network as a diffusion coefficient already stays in array form: inside `Dx(a(u) Dx(u))` the nonlinear Laplacian rule evaluates it on the half-point slices, in front of `Dxx(u)` it is mapped over the interior, and with ModelingToolkitNeuralNets loaded the network is batched in both places. This is the learned-diffusivity pattern for UDEs, and nothing covered it: the existing callable tests use the function as a source term, and the nonlinear Laplacian tests use symbolic coefficients.

| | interior array eqs | |
|---|---:|---|
| `Dx(a(u) Dx(u))`, `a(u) Dxx(u)`, `a` a registered function | 1 | matches the symbolic `1 + θ[1] u` form to 1e-8; 1e-6 through `mtkcompile` |
| `Dx(a([u, x]) Dx(u))`, stacked input | 1 | 1e-8 |
| `Dx((1 + NN(u)) Dx(u))`, `Dx((1 + NN([u, x])) Dx(u))`, `(1 + NN([u, x])) Dxx(u)` | 1 | batched; matches the point-by-point evaluation to 1e-8 |

The frame points of a nonlinear Laplacian stay pointwise; the tests check that their number does not change with the grid.