### PR TITLE
Release MethodOfLines 1.3.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `MethodOfLines` 1.3.0 -> 1.3.1 (patch).

Source files changed since 1.3.0:
- `ext/MethodOfLinesModelingToolkitNeuralNetsExt.jl`
- `src/discretization/discretize_equations.jl`
- `src/interface/solution/timedep.jl`
- `src/system_parsing/pde_system_transformation.jl`

Commits:
- Trim the array-form capability list from MOLFiniteDifference. (#673)
- Stop infinite expansion when a PDE unknown is missing from the system. (#674)
- Support vector-valued functions in ArrayDiscretization (#675)
- Test ModelingToolkitNeuralNets terms and fix the compiled ODE path (#678)
- Add a tutorial on training a neural network term in a PDE (#679)
- Stack vector field inputs and batch network calls in ArrayDiscretization (#680)
- Add a tutorial on learning the Brusselator reaction with a neural network (#681)
- Stack scalar inputs with field slices in ArrayDiscretization (#682)
- Test callable diffusion coefficients (#683)
- Reconstruct array observables once per PDE field (#676)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
