### PR TITLE
Add 32-bit Components CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,6 +1,12 @@
 [Components]
 versions = ["lts", "1", "pre"]
 
+["Components 32-bit"]
+group = "Components"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [Sol_Interface]
 versions = ["lts", "1", "pre"]
 


### PR DESCRIPTION

## Summary
- Add a `["Components 32-bit"]` matrix-only alias (`group = "Components"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- No `[Core]` group in this matrix; alias targets the primary `Components` lane.

## Test plan
- [ ] CI shows a job with `, x86)` for this group
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
