### PR TITLE
Keep array equations through the compiled ODEProblem path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# MethodOfLines.jl 1.5
+
+`ODEProblem(pdesys, discretization)` discretizes and compiles a time-dependent system into
+an `ODEProblem` for explicit time-stepping methods such as `Tsit5()`. With ModelingToolkit
+v11.43 / ModelingToolkitBase v1.70 or later, the compilation keeps the array (slice-form)
+equations (`mtkcompile(sys; scalarize_arrays = false)`), so the compiled `ODEProblem` path
+is now O(1) in the number of grid points like the `DAEProblem` path. `ode_compile(sys)`
+exposes that compilation step for systems obtained from `symbolic_discretize`; it falls
+back to the scalarizing `mtkcompile` when the array-preserving compilation does not yield
+an explicit ODE (for instance for systems second order in time), or with an older
+ModelingToolkit.
+
 # MethodOfLines.jl 1.0
 
 ## Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MethodOfLines"
 uuid = "94925ecb-adb7-4558-8ed8-f975c56a0bf4"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Alex Jones, <alex.jones@juliahub.com>"]
 
 [deps]

--- a/docs/src/MOLFiniteDifference.md
+++ b/docs/src/MOLFiniteDifference.md
@@ -72,8 +72,8 @@ system's initialization equations are ones that algorithm preserves.
 
 A few systems cannot be posed as a first-order DAE: those second order in time, and those
 whose initialization equations `BrownFullBasicInit` would not honour. They fall back to
-`mtkcompile` plus an `ODEProblem`, which scalarizes the array equations. Pass
-`fallback = false` to `discretize` to make that an error instead.
+`mtkcompile` plus an `ODEProblem`, see below. Pass `fallback = false` to `discretize` to
+make that an error instead.
 
 Time-independent systems have no derivative to keep implicit, and discretize to a
 `NonlinearProblem`.
@@ -84,28 +84,34 @@ The solution is a `PDETimeSeriesSolution` in every case, indexed and interpolate
 ## Explicit Runge–Kutta methods and other problem types
 
 Explicit Runge–Kutta methods such as `Tsit5()` and `SSPRK54()` solve `ODEProblem`s, not
-the `DAEProblem` returned by `discretize`. To use one, start from `symbolic_discretize`,
-which returns the discretized system and the time span, then compile the system into an
-`ODEProblem`:
+the `DAEProblem` returned by `discretize`. To use one, build the `ODEProblem` directly:
+
+```julia
+prob = ODEProblem(pdesys, disc)
+sol = solve(prob, Tsit5())
+```
+
+An `ODEProblem` needs `D(x) = f(x)`, so the discretized system is compiled with
+`mtkcompile` first. With ModelingToolkit v11.43 / ModelingToolkitBase v1.70 or later, the
+compilation keeps the array equations (`mtkcompile(sys; scalarize_arrays = false)`), so the
+compiled system and the generated code are independent of the grid resolution exactly like
+the `DAEProblem` path. That compilation does no tearing, so it is used only when every
+boundary condition can be eliminated and the result is an explicit ODE; otherwise the
+system is compiled with the default `mtkcompile`, which scalarizes the array equations.
+See [`ode_compile`](@ref) for the compilation step on its own, for instance when starting
+from `symbolic_discretize`:
 
 ```julia
 sys, tspan = symbolic_discretize(pdesys, disc)
-
-# an ODEProblem needs `D(x) = f(x)`, so compile first
-prob = ODEProblem(mtkcompile(sys), nothing, tspan)
-sol = solve(prob, Tsit5())
+prob = ODEProblem(ode_compile(sys), nothing, tspan)
 ```
 
 The discretized system also carries the time span itself, so `tspan` can be left out and
 the problem still spans the `PDESystem`'s time domain:
 
 ```julia
-prob = ODEProblem(mtkcompile(sys), nothing)
+prob = ODEProblem(ode_compile(sys), nothing)
 ```
-
-Note that `mtkcompile` scalarizes the array equations, so this path gives up the scaling
-benefit of the array form. Prefer `discretize` unless you specifically need an
-`ODEProblem` or an explicit time-stepping method.
 
 ## [Migrating to v1](@id migrating-to-v1)
 
@@ -115,5 +121,5 @@ benefit of the array form. Prefer `discretize` unless you specifically need an
   is unchanged.
 - Discretization strategy options were removed. MethodOfLines always uses array-form
   equations with automatic pointwise fallback for unsupported patterns.
-- To construct the pre-v1 compiled `ODEProblem`, use `symbolic_discretize` plus
-  `mtkcompile` as above.
+- To construct the pre-v1 compiled `ODEProblem`, use `ODEProblem(pdesys, disc)` or
+  `symbolic_discretize` plus `ode_compile` as above.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -72,7 +72,7 @@ discretization = MOLFiniteDifference(
     [x => dx, y => dy], t; advection_scheme = UpwindScheme())
 
 sys, tspan = symbolic_discretize(pdesys, discretization)
-prob = ODEProblem(mtkcompile(sys), nothing, tspan)
+prob = ODEProblem(ode_compile(sys), nothing, tspan)
 
 sol = solve(prob, SSPRK54(), dt = 0.01, saveat = 0.1)
 

--- a/docs/src/howitworks.md
+++ b/docs/src/howitworks.md
@@ -17,5 +17,6 @@ equal number of unknowns. See [the generated Brusselator system](@ref brusssys) 
 point count. Time-dependent systems are normally converted directly to a `DAEProblem`,
 which preserves symbolic array equations. Stationary systems are compiled with
 `ModelingToolkit.mtkcompile` into a `NonlinearProblem`; the optional compiled
-`ODEProblem` path also uses `mtkcompile` and scalarizes the equations. The problem
+`ODEProblem` path also uses `mtkcompile`, keeping the array equations where
+ModelingToolkit can preserve them (see [`ode_compile`](@ref)). The problem
 constructors generate executable Julia functions with `RuntimeGeneratedFunctions`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,10 +6,10 @@
     `DAEProblem` is therefore the new default for time-dependent systems; call
     `solve(prob)` to use the default DAE solver.
 
-    This improvement does not apply to `ODEProblem`. Explicit Runge–Kutta methods such as
-    `Tsit5()` and `SSPRK54()` require the compiled ODE path: `symbolic_discretize`, then
-    `mtkcompile`, then `ODEProblem`. See the [v1.0 migration guide](@ref migrating-to-v1)
-    for examples and compatibility details.
+    Explicit Runge–Kutta methods such as `Tsit5()` and `SSPRK54()` require the compiled
+    ODE path, `ODEProblem(pdesys, disc)`, which keeps the same O(1) compilation with a
+    recent ModelingToolkit. See the [v1.0 migration guide](@ref migrating-to-v1) for
+    examples and compatibility details.
 
 [MethodOfLines.jl](https://github.com/SciML/MethodOfLines.jl)
 is a Julia package for automated finite difference discretization

--- a/docs/src/staggered.md
+++ b/docs/src/staggered.md
@@ -40,7 +40,7 @@ domains = [t in Interval(0.0, tmax),
 
 discretization = MOLFiniteDifference([x=>dx], t, grid_align=MethodOfLines.StaggeredGrid(), edge_aligned_var=ϕ(t,x));
 sys, tspan = symbolic_discretize(pdesys, discretization)
-prob = ODEProblem(mtkcompile(sys), nothing, tspan);
+prob = ODEProblem(ode_compile(sys), nothing, tspan);
 
 sol = solve(prob, SplitEuler(), dt=dt);
 ```

--- a/docs/src/tutorials/nonuniform_weno.md
+++ b/docs/src/tutorials/nonuniform_weno.md
@@ -61,7 +61,7 @@ dx_uniform = 1.0 / N
 function solve_uniform(scheme; solver = Tsit5(), kwargs...)
     disc = MOLFiniteDifference([x => dx_uniform], t; advection_scheme = scheme)
     sys, tspan = symbolic_discretize(pdesys, disc)
-    prob = ODEProblem(mtkcompile(sys), nothing, tspan)
+    prob = ODEProblem(ode_compile(sys), nothing, tspan)
     return solve(prob, solver; saveat = 0.4, kwargs...)
 end
 
@@ -155,7 +155,7 @@ x_clustered = grid_from_density(0.0, 1.0, N + 1, ρ)
 disc_burgers = MOLFiniteDifference([x => x_clustered], t;
     advection_scheme = WENOScheme())
 sys, tspan = symbolic_discretize(pdesys_burgers, disc_burgers)
-prob_burgers = ODEProblem(mtkcompile(sys), nothing, tspan)
+prob_burgers = ODEProblem(ode_compile(sys), nothing, tspan)
 
 dt_burgers = 0.3 * minimum(diff(x_clustered)) / maximum(u0_burgers.(x_clustered))
 sol_burgers = solve(prob_burgers, SSPRK33(); dt = dt_burgers,
@@ -187,7 +187,7 @@ end
 
 disc_uni = MOLFiniteDifference([x => 1.0 / N], t; advection_scheme = WENOScheme())
 sys, tspan = symbolic_discretize(pdesys_burgers, disc_uni)
-prob_uni = ODEProblem(mtkcompile(sys), nothing, tspan)
+prob_uni = ODEProblem(ode_compile(sys), nothing, tspan)
 sol_uni = solve(prob_uni, SSPRK33(); dt = 0.3 / N / 0.9,
     saveat = [0.0, 0.35], adaptive = false)
 
@@ -231,7 +231,7 @@ function mms_error(xgrid; tf = 0.05)
     @named pdesys_mms = PDESystem(eq_mms, bcs_mms, domains_mms, [t, x], [u(t, x)])
     disc = MOLFiniteDifference([x => xgrid], t; advection_scheme = WENOScheme())
     sys, tspan = symbolic_discretize(pdesys_mms, disc)
-    prob = ODEProblem(mtkcompile(sys), nothing, tspan)
+    prob = ODEProblem(ode_compile(sys), nothing, tspan)
     dt = 0.01 * minimum(diff(xgrid)) # tiny dt isolates the spatial error
     sol = solve(prob, SSPRK33(); dt, saveat = [0.0, tf], adaptive = false)
     xg = sol[x]

--- a/docs/src/tutorials/sispde.md
+++ b/docs/src/tutorials/sispde.md
@@ -107,7 +107,7 @@ See more solvers in [Steady State Solvers · DifferentialEquations.jl](https://d
 
 ```@example sispde
 sys, tspan = symbolic_discretize(pdesys, discretization)
-odeprob = ODEProblem(mtkcompile(sys), nothing, tspan)
+odeprob = ODEProblem(ode_compile(sys), nothing, tspan)
 steadystateprob = SteadyStateProblem(odeprob)
 steadystate = solve(steadystateprob, DynamicSS(FBDF()))
 ```

--- a/docs/src/tutorials/weno_showcase.md
+++ b/docs/src/tutorials/weno_showcase.md
@@ -51,7 +51,7 @@ function shock_prob(gridspec, scheme)
     @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
     disc = MOLFiniteDifference([x => gridspec], t; advection_scheme = scheme)
     sys, tspan = symbolic_discretize(pdesys, disc)
-    return ODEProblem(mtkcompile(sys), nothing, tspan)
+    return ODEProblem(ode_compile(sys), nothing, tspan)
 end
 nothing # hide
 ```
@@ -223,7 +223,7 @@ function front_prob(g1, g2)
     disc = MOLFiniteDifference([x1 => g1, x2 => g2], t;
         advection_scheme = WENOScheme())
     sys, tspan = symbolic_discretize(pdesys, disc)
-    return ODEProblem(mtkcompile(sys), nothing, tspan)
+    return ODEProblem(ode_compile(sys), nothing, tspan)
 end
 
 # ρ ∝ s: domain 2 gets ~2x the density; grids are deliberately mismatched at the seam.

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -147,7 +147,7 @@ function ODEFunctionExpr(
         if tspan === nothing
             @assert true "Codegen for NonlinearSystems is not yet implemented."
         else
-            simpsys = mtkcompile(sys)
+            simpsys = ode_compile(sys)
             return ODEFunction(simpsys; expression = Val{true})
         end
     catch e
@@ -169,7 +169,7 @@ function SciMLBase.ODEFunction(
         if tspan === nothing
             @assert true "Codegen for NonlinearSystems is not yet implemented."
         else
-            simpsys = mtkcompile(sys)
+            simpsys = ode_compile(sys)
             f_analytic = nothing
             if analytic !== nothing
                 analytic = analytic isa Dict ? analytic : Dict(analytic)
@@ -222,7 +222,7 @@ needed and the array (slice-form) equations reach the generated code intact. Cal
 
 A few systems cannot be posed as a first-order DAE — those second order in time, and
 those whose initialization equations `BrownFullBasicInit` would not honour. Those fall
-back to `mtkcompile` plus an `ODEProblem`, which scalarizes the array equations. Pass
+back to `mtkcompile` plus an `ODEProblem` (see [`ode_compile`](@ref)). Pass
 `fallback = false` to make that an error instead.
 
 Supplying `analytic` selects the compiled `ODEProblem` path because analytic solutions
@@ -232,12 +232,10 @@ Time-independent systems have no derivative to keep implicit and discretize to a
 `NonlinearProblem` as before.
 
 Explicit Runge–Kutta methods such as `Tsit5()` solve `ODEProblem`s, not the `DAEProblem`
-returned by this method. To use one, start from `symbolic_discretize` and compile the
-discretized system:
+returned by this method. To use one, build the `ODEProblem` directly:
 
 ```julia
-sys, tspan = symbolic_discretize(pdesys, discretization)
-prob = ODEProblem(mtkcompile(sys), nothing, tspan)
+prob = ODEProblem(pdesys, discretization)
 sol = solve(prob, Tsit5())
 ```
 """
@@ -271,11 +269,66 @@ function _stationary_problem(sys, discretization::MOLFiniteDifference; kwargs...
     )
 end
 
+"""
+    ODEProblem(pdesys::PDESystem, discretization::MOLFiniteDifference; kwargs...)
+
+Discretize `pdesys` and build an `ODEProblem` from the compiled system, for explicit
+time-stepping methods such as `Tsit5()` that cannot solve the `DAEProblem` returned by
+[`discretize`](@ref). See [`ode_compile`](@ref) for how the array equations are kept
+through `mtkcompile`.
+"""
+function SciMLBase.ODEProblem(
+        pdesys::PDESystem, discretization::MOLFiniteDifference; analytic = nothing, kwargs...
+    )
+    sys, tspan = SciMLBase.symbolic_discretize(pdesys, discretization)
+    if tspan === nothing
+        throw(
+            ArgumentError(
+                "`ODEProblem` requires a time variable; pass one to `MOLFiniteDifference`, or use `discretize` for the `NonlinearProblem` a time-independent system discretizes to."
+            )
+        )
+    end
+    return _ode_problem(sys, tspan, pdesys, discretization; analytic, kwargs...)
+end
+
+# Whether the installed ModelingToolkit can keep array equations through `mtkcompile`.
+const PRESERVES_ARRAY_EQUATIONS = isdefined(ModelingToolkitBase, :arrays_scalarized)
+
+_isdiffeq(eq) = iscall(safe_unwrap(eq.lhs)) && operation(safe_unwrap(eq.lhs)) isa Differential
+
+"""
+    ode_compile(sys)
+
+Compile a discretized system for an `ODEProblem`. When ModelingToolkit supports it,
+`mtkcompile(sys; scalarize_arrays = false)` keeps the array (slice-form) equations, so the
+compiled system and its generated code stay independent of the grid resolution like the
+`DAEProblem` path. That compilation does no tearing, so it is used only when it yields an
+explicit ODE: every remaining equation is `D(x) ~ f`. Otherwise, or with a ModelingToolkit
+that cannot preserve array equations, this falls back to the default `mtkcompile`, which
+scalarizes the array equations.
+"""
+function ode_compile(sys)
+    if PRESERVES_ARRAY_EQUATIONS
+        simpsys = try
+            mtkcompile(sys; scalarize_arrays = false)
+        catch e
+            e isa InterruptException && rethrow(e)
+            @debug "Falling back to scalarizing `mtkcompile`: $(sprint(showerror, e))"
+            nothing
+        end
+        if simpsys !== nothing
+            all(_isdiffeq, get_eqs(simpsys)) && return simpsys
+            @debug "Falling back to scalarizing `mtkcompile`: the array-preserving compilation left algebraic equations"
+        end
+    end
+    return mtkcompile(sys)
+end
+
 function _ode_problem(
         sys, tspan, pdesys, discretization::MOLFiniteDifference; analytic = nothing,
         kwargs...
     )
-    simpsys = mtkcompile(sys)
+    simpsys = ode_compile(sys)
     PDEBase.add_metadata!(
         getmetadata(simpsys, ModelingToolkit.ProblemTypeCtx, nothing), sys
     )

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -139,7 +139,7 @@ include("precompile.jl")
 
 # Export
 export MOLFiniteDifference, discretize, symbolic_discretize, ODEFunctionExpr, generate_code,
-    edge_align, center_align, get_discrete, chebyspace
+    ode_compile, edge_align, center_align, get_discrete, chebyspace
 export UpwindScheme, WENOScheme, FunctionalScheme, MOLDiscCallback
 
 end

--- a/src/dae_discretization.jl
+++ b/src/dae_discretization.jl
@@ -1,10 +1,10 @@
 # DAEProblem construction, preserving array (slice-form) equations.
 #
-# `discretize` runs `mtkcompile`, which scalarizes array equations before codegen: an
-# `ODEProblem` needs `D(x) = f(x)`, and isolating the derivative is structural
-# simplification. MethodOfLines already emits residuals `D(u) - f ~ 0`, which is exactly
-# the implicit-DAE form `DAEProblem` consumes, so this path skips `mtkcompile` and the
-# array equations survive into the generated code.
+# MethodOfLines emits residuals `D(u) - f ~ 0`, which is exactly the implicit-DAE form
+# `DAEProblem` consumes, so this path skips `mtkcompile` altogether and the array
+# equations survive into the generated code. The `ODEProblem` path (`ode_compile`) needs
+# `mtkcompile` to isolate the derivatives and eliminate the boundary equations, and keeps
+# the array equations only where ModelingToolkit can preserve them through that.
 
 """
     BrownFullBasicInitUnsafeError(offenders)

--- a/test/Discretization/problem_construction.jl
+++ b/test/Discretization/problem_construction.jl
@@ -3,6 +3,7 @@
 
 using MethodOfLines, ModelingToolkit, OrdinaryDiffEq, DomainSets, Symbolics
 using SciMLBase
+using SymbolicUtils, LinearAlgebra
 using DiffEqBase: BrownFullBasicInit, ShampineCollocationInit
 using OrdinaryDiffEqRosenbrock: Rodas4
 using ModelingToolkit: get_eqs
@@ -279,6 +280,73 @@ end
     prob = ODEProblem(mtkcompile(sys), nothing, tspan)
     @test prob isa SciMLBase.ODEProblem
     @test SciMLBase.successful_retcode(solve(prob, Tsit5()))
+
+    prob2 = ODEProblem(pdesys, disc)
+    @test prob2 isa SciMLBase.ODEProblem
+    @test prob2.tspan == tspan
+    sol = solve(prob2, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol isa SciMLBase.PDETimeSeriesSolution
+    @test sol(0.1, 0.5)[1] ≈ sinpi(0.5) * exp(-pi^2 * 0.1) rtol = 1.0e-2
+end
+
+# With a ModelingToolkit that can keep array equations through `mtkcompile`, the compiled
+# `ODEProblem` path stays O(1) in the grid resolution like the `DAEProblem` path. With an
+# older one, `ode_compile` is the plain `mtkcompile`.
+@testset "array-preserving ODE path" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+    bcs = [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.1), x ∈ Interval(0.0, 1.0)]
+    @named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+    treesize(x) = let u = Symbolics.unwrap(x)
+        SymbolicUtils.iscall(u) ? 1 + sum(treesize, SymbolicUtils.arguments(u); init = 0) : 1
+    end
+    syssize(sys) = sum(eq -> treesize(eq.lhs) + treesize(eq.rhs), get_eqs(sys))
+
+    sizes = map((11, 21, 41, 81)) do n
+        disc = mol_disc([x => n], t)
+        sys, tspan = symbolic_discretize(pdesys, disc)
+        csys = ode_compile(sys)
+        @test length(unknowns(csys)) == n - 2
+        prob = ODEProblem(pdesys, disc)
+        @test prob.f.mass_matrix === LinearAlgebra.I
+        sol = solve(prob, Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
+        @test SciMLBase.successful_retcode(sol)
+        xs = range(0.0, 1.0, length = n)
+        # second order accurate in space
+        @test maximum(abs, sol[u(t, x)][end, :] .- @.(sinpi(xs) * exp(-pi^2 * 0.1))) <
+            1.0 / n^2
+        (length(get_eqs(csys)), syssize(csys), any(isarrayeq, get_eqs(csys)))
+    end
+    if MethodOfLines.PRESERVES_ARRAY_EQUATIONS
+        @test allequal(first.(sizes))
+        @test allequal(getindex.(sizes, 2))
+        @test all(last, sizes)
+        @test first(sizes)[1] == 1
+    else
+        @test first.(sizes) == (11, 21, 41, 81) .- 2
+        @test !any(last, sizes)
+    end
+
+    # second order in time: no array-preserving compilation, so `ode_compile` scalarizes
+    Dtt = Differential(t)^2
+    @named wave = PDESystem(
+        Dtt(u(t, x)) ~ Dxx(u(t, x)),
+        [u(0, x) ~ sinpi(x), Dt(u(0, x)) ~ 0.0, u(t, 0) ~ 0.0, u(t, 1) ~ 0.0],
+        domains, [t, x], [u(t, x)]
+    )
+    disc = mol_disc([x => 11], t)
+    wsys = ode_compile(first(symbolic_discretize(wave, disc)))
+    @test !any(isarrayeq, get_eqs(wsys))
+    @test SciMLBase.successful_retcode(
+        solve(ODEProblem(wave, disc), Tsit5(); reltol = 1.0e-8, abstol = 1.0e-8)
+    )
 end
 
 # The predicate's algebraic-variable and coupled-unknown branches are unreachable from what


### PR DESCRIPTION
## Summary

`discretize` preserves the array (slice-form) equations by building a `DAEProblem` without `mtkcompile`, but the `ODEProblem` path needed by explicit Runge–Kutta methods (`Tsit5`, `SSPRK54`, ...) still went through the scalarizing `mtkcompile`, so its compile time grew with the grid.

ModelingToolkit can now keep array equations through compilation with `mtkcompile(sys; scalarize_arrays = false)` (SciML/ModelingToolkit.jl#5100 and SciML/ModelingToolkit.jl#5101). This PR uses that for the compiled `ODEProblem` path, so the same O(1) examples work for `ODEProblem`.

### What changes

- `ode_compile(sys)` (exported): `mtkcompile(sys; scalarize_arrays = false)` when the installed ModelingToolkit supports it and the result is an explicit ODE (every remaining equation is `D(x) ~ f`); otherwise the default `mtkcompile`. The fallback covers older ModelingToolkit versions (detected with `isdefined(ModelingToolkitBase, :arrays_scalarized)`) and systems the tearing-free compiler cannot make explicit (second order in time, coupled algebraic equations).
- `_ode_problem`, `ODEFunction` and `ODEFunctionExpr` go through `ode_compile`.
- New `ODEProblem(pdesys, discretization; kwargs...)` constructor, so the compiled path no longer requires `symbolic_discretize` + `mtkcompile` by hand.
- Docs (`MOLFiniteDifference.md`, `index.md`, `howitworks.md`, FAQ, tutorials) no longer say the ODE path always scalarizes, and use `ode_compile` / `ODEProblem(pdesys, disc)`. NEWS entry for 1.5; version bumped to 1.5.0.

### Tests

`test/Discretization/problem_construction.jl`:
- `ODEProblem(pdesys, disc)` for the 1D heat equation solves with `Tsit5` to the analytic solution;
- "array-preserving ODE path": for 11, 21, 41 and 81 grid points the compiled system has `n - 2` unknowns, `mass_matrix === I`, second-order accuracy, and — when ModelingToolkit preserves array equations — exactly one equation with a symbolic tree size independent of `n`. With an older ModelingToolkit the test instead asserts the scalarized shape, so CI passes with the current release too;
- the wave equation (second order in time) falls back to the scalarizing compilation and still solves.

Run locally against the ModelingToolkit branches above: `problem_construction.jl` 81/81 pass (with the released ModelingToolkit the fallback branch of the tests is exercised).

### How to verify the O(1) scaling

```julia
using MethodOfLines, ModelingToolkit, DomainSets, OrdinaryDiffEq
@parameters t x
@variables u(..)
Dt = Differential(t); Dxx = Differential(x)^2
@named pdesys = PDESystem(Dt(u(t, x)) ~ Dxx(u(t, x)),
    [u(0, x) ~ sinpi(x), u(t, 0) ~ 0.0, u(t, 1) ~ 0.0],
    [t ∈ Interval(0.0, 0.1), x ∈ Interval(0.0, 1.0)], [t, x], [u(t, x)])
for n in (11, 81, 641)
    sys, _ = symbolic_discretize(pdesys, MOLFiniteDifference([x => n], t))
    csys = ode_compile(sys)
    @show n length(equations(csys))   # 1 for every n with MTK ≥ 11.43
    solve(ODEProblem(pdesys, MOLFiniteDifference([x => n], t)), Tsit5())
end
```

Depends on SciML/ModelingToolkit.jl#5100 and SciML/ModelingToolkit.jl#5101 for the preserved path; degrades to the previous behaviour without them.

Made with [Cursor](https://cursor.com)