### PR TITLE
Add PseudospectralDiscretization (Chebyshev + Fourier collocation)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,15 +22,19 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [weakdeps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 ModelingToolkitNeuralNets = "f162e290-f571-43a6-83d9-22ecc16da15f"
 
 [extensions]
+MethodOfLinesAbstractFFTsExt = "AbstractFFTs"
 MethodOfLinesModelingToolkitNeuralNetsExt = "ModelingToolkitNeuralNets"
 
 [compat]
+AbstractFFTs = "1"
 Combinatorics = "1"
 DiffEqBase = "7.18.1"
 DomainSets = "0.7, 0.8"
+FFTW = "1"
 ForwardDiff = "1"
 Interpolations = "0.15, 0.16"
 Latexify = "0.16"
@@ -59,6 +63,7 @@ Test = "1"
 julia = "1.10"
 
 [extras]
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
@@ -72,4 +77,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ForwardDiff", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqSSPRK", "SafeTestsets", "SciMLTesting", "StableRNGs"]
+test = ["Test", "FFTW", "ForwardDiff", "NonlinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqSSPRK", "SafeTestsets", "SciMLTesting", "StableRNGs"]

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -15,6 +15,7 @@ pages = [
         "tutorials/schroedinger.md",
     ],
     "MOLFiniteDifference" => "MOLFiniteDifference.md",
+    "PseudospectralDiscretization" => "pseudospectral.md",
     "Solution Interface - PDESolutions" => "solutions.md",
     "Grid and Solution Retrieval - Deprecated" => "get_grid.md",
     "Boundary Conditions" => "boundary_conditions.md",

--- a/docs/src/pseudospectral.md
+++ b/docs/src/pseudospectral.md
@@ -8,19 +8,34 @@ struct PseudospectralDiscretization <: AbstractEquationSystemDiscretization
 end
 ```
 
-`PseudospectralDiscretization` discretizes a `PDESystem` by collocation on
-spectral grids: every spatial derivative `Differential(x)^d` is replaced by the
-dense differentiation matrix of the spectral interpolant in that direction, and
-boundary conditions replace the equation at the boundary points, exactly as in
-[`MOLFiniteDifference`](@ref molfd). This mirrors the handwritten
-pseudospectral implementations in the
-SciMLBenchmarks ([Allen–Cahn](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/allen_cahn_spectral_wpd/),
+`PseudospectralDiscretization` discretizes a `PDESystem` by collocation on spectral
+grids. The unknowns are the values of each dependent variable at the collocation
+nodes, exactly as for [`MOLFiniteDifference`](@ref molfd); the difference is the
+derivative approximation. Every spatial derivative `Differential(x)^d` is replaced by
+the dense differentiation matrix of the spectral interpolant through the nodes in
+that direction, so a derivative at one node involves the values at all nodes of the
+direction rather than a fixed stencil. Nonlinear terms are evaluated pointwise on
+the grid. The discretization works entirely in physical (grid) space: no transform to
+spectral coefficients is taken, and no FFT is used. For a periodic direction the
+dense trigonometric differentiation matrix computes the same result the
+`ifft(ik .* fft(u))` route would, at `O(n^2)` rather than `O(n log n)` cost per
+application.
+
+This is the collocation family used by the SciMLBenchmarks
+`SimpleHandwrittenPDE` spectral work-precision benchmarks
+([Allen–Cahn](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/allen_cahn_spectral_wpd/),
 [Burgers](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/burgers_spectral_wpd/),
 [KdV](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/kdv_spectral_wpd/) and
 [Kuramoto–Sivashinsky](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/ks_spectral_wpd/)),
-which are based on
-`ClassicalOrthogonalPolynomials` Chebyshev collocation and
-`SummationByPartsOperators` Fourier differentiation.
+which also apply dense differentiation matrices in grid space. The periodic
+benchmarks convert the `SummationByPartsOperators` Fourier operator to the same
+dense matrix `FourierCollocation` builds. The non-periodic benchmarks use
+rectangular collocation from `ClassicalOrthogonalPolynomials` (the equation is
+imposed on `n - 2` first-kind Chebyshev points and mapped back through a
+resampling mass matrix), whereas `ChebyshevCollocation` uses square
+Chebyshev–Lobatto collocation with the boundary rows replaced by the boundary
+conditions, as in Trefethen's *Spectral Methods in MATLAB*. Both are spectrally
+accurate; the discrete operators are not identical.
 
 ```julia
 eq = [your system of equations, see examples for possibilities]
@@ -38,18 +53,17 @@ Here `dxs` is a vector of pairs mapping each independent variable to a
 collocation specification:
 
 - `x => n::Integer` or `x => ChebyshevCollocation(n)`: discretize `x` on `n`
-  Chebyshev–Lobatto points `x_k = a + (b - a)/2 * (1 - cos(π(k - 1)/(n - 1)))`.
-  Use for non-periodic directions; truncating boundary conditions (Dirichlet,
-  Neumann, Robin, higher-order) are applied as usual.
-- `x => FourierCollocation(n)`: discretize `x` on `n` distinct equispaced
-  points of the periodic interval `[a, b)`. A periodic boundary condition
-  `u(t, a) ~ u(t, b)` is required for every dependent variable in that
-  direction; derivative matching conditions such as
-  `Differential(x)(u(t, a)) ~ Differential(x)(u(t, b))` are redundant - they
-  hold identically for the trigonometric interpolant - and are skipped.
-- `x => grid::AbstractVector`: a custom set of `n` collocation nodes;
-  derivatives are the polynomial-interpolant (Fornberg) differentiation
-  matrices on those nodes.
+  Chebyshev–Lobatto points `x_k = a + (b - a)/2 * (1 - cos(π(k - 1)/(n - 1)))`,
+  which include both endpoints. Derivatives are those of the degree `n - 1`
+  polynomial interpolant. Use for non-periodic directions.
+- `x => FourierCollocation(n)`: discretize `x` on `n` distinct equispaced points
+  of the periodic interval `[a, b)`. Derivatives are those of the trigonometric
+  interpolant. A periodic boundary condition `u(t, a) ~ u(t, b)` is required for
+  every dependent variable in that direction.
+- `x => grid::AbstractVector`: a custom set of `n` nodes spanning the domain;
+  derivatives are those of the polynomial interpolant through the nodes (Fornberg
+  weights over the whole grid). Clustered nodes such as Chebyshev points are needed
+  for this to be well conditioned; equispaced nodes suffer the Runge phenomenon.
 
 The second argument `time` is the continuous variable; if `time = nothing`,
 discretization yields a `NonlinearProblem`.
@@ -75,20 +89,118 @@ sol = solve(prob)
 sol[u(t, x)] # solution on the collocation grid
 ```
 
-## Notes
+## Boundary conditions on Chebyshev directions
 
-- Nested derivative terms such as `Differential(x)(a(u) * Differential(x)(u))`
-  or `Differential(x)(u^2)` are evaluated directly by collocation, so no
-  PDE-system transformation is performed for this discretization.
-- Derivative BCs such as `Differential(x)(u(t, a)) ~ 0` are enforced through
-  the differentiation matrix row at the boundary.
-- Fourier directions are differentiated with the explicit trigonometric
-  interpolant matrix raised to the requested order; all other grids use the
-  maximal-stencil Fornberg weights, i.e. the polynomial interpolant.
-- Spectral differentiation matrices are dense, so symbolic equation generation
-  scales `O(n^2)` in the number of collocation points per direction, and the
-  generated RHS is dense. This discretization is best for small `n` where
-  spectral accuracy dominates, or for prototyping; for large systems or when
-  sparsity matters, `MOLFiniteDifference` is more appropriate.
-- `Integral` terms and multi-domain (interface) boundary conditions are not
-  supported.
+A Chebyshev–Lobatto grid contains both endpoints, and the boundary values are
+unknowns of the discretized system. The PDE is imposed at the interior nodes. At
+each boundary node, the PDE is not imposed; the equation for that node is the
+boundary condition itself, written in terms of the grid values. Concretely, for
+`u(t, x)` on `n` nodes with one condition at each end, the discretized system is
+`n - 2` interior equations plus the two boundary equations, with `n` unknowns.
+
+Derivatives in a boundary condition are the boundary rows of the differentiation
+matrices: `Differential(x)(u(t, a))` becomes the first row of the first-derivative
+matrix dotted with all `n` values in that direction, which is the exact derivative
+of the interpolant at the endpoint. This makes the following conditions work
+without any special handling, on their own or combined at the same boundary:
+
+- Dirichlet, constant or time-dependent: `u(t, a) ~ 1.0`, `u(t, a) ~ sin(t)`.
+- Neumann: `Differential(x)(u(t, a)) ~ 0.0`.
+- Robin and nonlinear conditions: `Differential(x)(u(t, a)) + u(t, a) ~ 0.0`,
+  `Differential(x)(u(t, b)) ~ u(t, b)^2`.
+- Higher-order conditions: `(Differential(x)^2)(u(t, a)) ~ 0.0`, for any derivative
+  order below the number of nodes.
+- Conditions on other variables of a coupled system, and, in more than one
+  dimension, conditions varying along the boundary face such as
+  `u(t, a, y) ~ sin(y)`.
+
+Each boundary condition at an end of a direction removes the PDE from one more
+node at that end. A second-order equation takes one condition per end. A
+fourth-order equation such as a clamped beam takes two, e.g. `u(t, a) ~ 0.0` and
+`Differential(x)(u(t, a)) ~ 0.0`, and the PDE is then imposed on `n - 4` nodes. A
+first-order equation such as advection takes a condition at the inflow end only:
+where no condition is given, the PDE is imposed at the boundary node itself.
+
+Because the boundary values are unknowns constrained algebraically, the
+time-dependent system is a differential-algebraic system of index 1.
+[`discretize`](@ref) returns a `DAEProblem` with `BrownFullBasicInit()`, which
+solves the boundary equations for the boundary values at the initial time; the
+initial condition is used at the interior nodes only, so a mismatch between the
+initial condition and the boundary conditions at the corners of the domain is
+tolerated. The compiled `ODEProblem` path (`symbolic_discretize` followed by
+`mtkcompile`) instead eliminates the boundary unknowns: Dirichlet values are
+substituted, and derivative conditions are solved for the boundary value in terms
+of the interior values.
+
+Boundary conditions must sit at the ends of the domain. Periodic conditions are not
+accepted on a Chebyshev direction: use `FourierCollocation` for that direction.
+Multi-domain interface conditions between different variables are not supported.
+
+## Boundary conditions on Fourier directions
+
+`FourierCollocation(n)` stores `n + 1` grid points, the last being the same
+physical node as the first, so that the solution interface reports the value at
+both ends of the domain. The upper endpoint is an algebraic unknown pinned by the
+periodic condition `u(t, a) ~ u(t, b)`, which is the only condition the direction
+needs. Derivatives never involve the duplicated node: each differentiation row acts
+on the `n` distinct values, and the row for the upper endpoint is the row of the
+lower one.
+
+Derivative matching conditions such as
+`Differential(x)(u(t, a)) ~ Differential(x)(u(t, b))` hold identically for the
+trigonometric interpolant. They are checked and skipped, so they may be included
+for readability but add no equations. A matching condition with a jump, such as
+`Differential(x)(u(t, a)) ~ Differential(x)(u(t, b)) + 1`, cannot be represented
+and raises an error. Truncating conditions such as Dirichlet values are rejected on
+a Fourier direction.
+
+In two dimensions, the corner grid points at the duplicated index of a periodic
+direction are not connected to the interior and are pinned to zero by the corner
+equations, as on the finite difference path. They are visible only as those corner
+entries of `sol[u(t, x, y)]`.
+
+## Array form and scaling
+
+The interior of each PDE is emitted as a single symbolic array equation over slices
+of the discretized variables, in the same way as the
+[array form of `MOLFiniteDifference`](@ref molfd). Each spatial derivative is an
+opaque operator holding the rows of the differentiation matrix for the interior
+nodes, applied along its axis to the full slice of its argument:
+
+```julia
+Differential(t)(u[2:n-1]) ~ SpectralApply(D2[2:n-1, :])(u[1:n]) - u[2:n-1] .^ 3
+```
+
+Nonlinear terms broadcast over the slices, and nested derivative terms evaluate
+their argument on the whole direction before applying the outer operator, so
+`Differential(x)(a(u) * Differential(x)(u))` becomes
+`D1 * (a.(u) .* (D1 * u))` on slices. Boundary conditions on the faces of a 2D
+domain are array equations as well, so the number of symbolic equations is
+independent of the resolution in one and two dimensions. The differentiation
+matrices are held inside the operators rather than written into the expression
+tree, so the size of the generated code is independent of the resolution too.
+Systems with three or more spatial dimensions, stationary systems, and equations
+containing patterns without a slice form fall back to one scalar equation per grid
+point, each carrying a full differentiation row.
+
+The `DAEProblem` returned by [`discretize`](@ref) keeps this array form.
+`mtkcompile` scalarizes it into one equation per unknown, each referencing the
+shared matrix products, which the generated code evaluates once per call.
+
+At run time each derivative costs a dense matrix product: `O(n^2)` per
+application in one dimension and `O(n^2 m + n m^2)` on an `n × m` grid. This is
+the same cost as the handwritten benchmark implementations. The Jacobian is dense.
+For a few hundred nodes per direction this is fast; for larger periodic problems an
+FFT-based operator would be `O(n log n)`, which this discretization does not
+provide.
+
+## Limitations
+
+- `Integral` terms are not supported.
+- Multi-domain (interface) boundary conditions are not supported; only
+  same-variable periodic conditions with `FourierCollocation`.
+- There is no upwinding or scheme selection: all derivative orders in a direction
+  share the same spectral differentiation matrix. Discontinuous solutions produce
+  Gibbs oscillations, as with any global spectral method.
+- Derivatives are dense, so the number of nodes per direction should stay in the
+  hundreds.

--- a/docs/src/pseudospectral.md
+++ b/docs/src/pseudospectral.md
@@ -1,0 +1,94 @@
+# [Pseudospectral Discretization](@id pseudospectral)
+
+```julia
+struct PseudospectralDiscretization <: AbstractEquationSystemDiscretization
+    dxs::Any
+    time::Any
+    kwargs::Any
+end
+```
+
+`PseudospectralDiscretization` discretizes a `PDESystem` by collocation on
+spectral grids: every spatial derivative `Differential(x)^d` is replaced by the
+dense differentiation matrix of the spectral interpolant in that direction, and
+boundary conditions replace the equation at the boundary points, exactly as in
+[`MOLFiniteDifference`](@ref molfd). This mirrors the handwritten
+pseudospectral implementations in the
+SciMLBenchmarks ([Allen–Cahn](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/allen_cahn_spectral_wpd/),
+[Burgers](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/burgers_spectral_wpd/),
+[KdV](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/kdv_spectral_wpd/) and
+[Kuramoto–Sivashinsky](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/ks_spectral_wpd/)),
+which are based on
+`ClassicalOrthogonalPolynomials` Chebyshev collocation and
+`SummationByPartsOperators` Fourier differentiation.
+
+```julia
+eq = [your system of equations, see examples for possibilities]
+bcs = [your boundary conditions, see examples for possibilities]
+
+domains = [your domain, a vector of Intervals i.e. x ∈ Interval(x_min, x_max)]
+
+@named pdesys = PDESystem(eq, bcs, domains, [t, x], [u(t, x)])
+
+discretization = PseudospectralDiscretization(dxs, t)
+prob = discretize(pdesys, discretization)
+```
+
+Here `dxs` is a vector of pairs mapping each independent variable to a
+collocation specification:
+
+- `x => n::Integer` or `x => ChebyshevCollocation(n)`: discretize `x` on `n`
+  Chebyshev–Lobatto points `x_k = a + (b - a)/2 * (1 - cos(π(k - 1)/(n - 1)))`.
+  Use for non-periodic directions; truncating boundary conditions (Dirichlet,
+  Neumann, Robin, higher-order) are applied as usual.
+- `x => FourierCollocation(n)`: discretize `x` on `n` distinct equispaced
+  points of the periodic interval `[a, b)`. A periodic boundary condition
+  `u(t, a) ~ u(t, b)` is required for every dependent variable in that
+  direction; derivative matching conditions such as
+  `Differential(x)(u(t, a)) ~ Differential(x)(u(t, b))` are redundant - they
+  hold identically for the trigonometric interpolant - and are skipped.
+- `x => grid::AbstractVector`: a custom set of `n` collocation nodes;
+  derivatives are the polynomial-interpolant (Fornberg) differentiation
+  matrices on those nodes.
+
+The second argument `time` is the continuous variable; if `time = nothing`,
+discretization yields a `NonlinearProblem`.
+
+## Example
+
+```julia
+using MethodOfLines, ModelingToolkit, DomainSets, OrdinaryDiffEq
+
+@parameters t x
+@variables u(..)
+Dt = Differential(t)
+Dxx = Differential(x)^2
+
+# Heat equation on a Chebyshev-Lobatto grid
+eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+bcs = [u(0, x) ~ cospi(x / 2), u(t, -1) ~ 0.0, u(t, 1) ~ 0.0]
+domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-1.0, 1.0)]
+@named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+
+prob = discretize(pdesys, PseudospectralDiscretization([x => 32], t))
+sol = solve(prob)
+sol[u(t, x)] # solution on the collocation grid
+```
+
+## Notes
+
+- Nested derivative terms such as `Differential(x)(a(u) * Differential(x)(u))`
+  or `Differential(x)(u^2)` are evaluated directly by collocation, so no
+  PDE-system transformation is performed for this discretization.
+- Derivative BCs such as `Differential(x)(u(t, a)) ~ 0` are enforced through
+  the differentiation matrix row at the boundary.
+- Fourier directions are differentiated with the explicit trigonometric
+  interpolant matrix raised to the requested order; all other grids use the
+  maximal-stencil Fornberg weights, i.e. the polynomial interpolant.
+- Spectral differentiation matrices are dense, so symbolic equation generation
+  scales `O(n^2)` in the number of collocation points per direction, and the
+  generated RHS is dense. This discretization is best for small `n` where
+  spectral accuracy dominates, or for prototyping; for large systems or when
+  sparsity matters, `MOLFiniteDifference` is more appropriate.
+- `Integral` terms and multi-domain (interface) boundary conditions are not
+  supported.

--- a/docs/src/pseudospectral.md
+++ b/docs/src/pseudospectral.md
@@ -15,11 +15,11 @@ derivative approximation. Every spatial derivative `Differential(x)^d` is replac
 the dense differentiation matrix of the spectral interpolant through the nodes in
 that direction, so a derivative at one node involves the values at all nodes of the
 direction rather than a fixed stencil. Nonlinear terms are evaluated pointwise on
-the grid. The discretization works entirely in physical (grid) space: no transform to
-spectral coefficients is taken, and no FFT is used. For a periodic direction the
-dense trigonometric differentiation matrix computes the same result the
-`ifft(ik .* fft(u))` route would, at `O(n^2)` rather than `O(n log n)` cost per
-application.
+the grid. The discretization works entirely in physical (grid) space: the unknowns
+are never transformed to spectral coefficients. For a periodic direction the
+derivative is `irfft((ik)^d .* rfft(u))` when an `AbstractFFTs` backend such as
+`FFTW` is loaded, and the equivalent dense trigonometric differentiation matrix
+otherwise; see [FFT derivatives](@ref pseudospectral-fft).
 
 This is the collocation family used by the SciMLBenchmarks
 `SimpleHandwrittenPDE` spectral work-precision benchmarks
@@ -59,7 +59,8 @@ collocation specification:
 - `x => FourierCollocation(n)`: discretize `x` on `n` distinct equispaced points
   of the periodic interval `[a, b)`. Derivatives are those of the trigonometric
   interpolant. A periodic boundary condition `u(t, a) ~ u(t, b)` is required for
-  every dependent variable in that direction.
+  every dependent variable in that direction. `FourierCollocation(n; fft = false)`
+  keeps the dense matrix even when an FFT backend is loaded.
 - `x => grid::AbstractVector`: a custom set of `n` nodes spanning the domain;
   derivatives are those of the polynomial interpolant through the nodes (Fornberg
   weights over the whole grid). Clustered nodes such as Chebyshev points are needed
@@ -154,7 +155,7 @@ for readability but add no equations. A matching condition with a jump, such as
 and raises an error. Truncating conditions such as Dirichlet values are rejected on
 a Fourier direction.
 
-In two dimensions, the corner grid points at the duplicated index of a periodic
+In more than one dimension, the corner grid points at the duplicated index of a periodic
 direction are not connected to the interior and are pinned to zero by the corner
 equations, as on the finite difference path. They are visible only as those corner
 entries of `sol[u(t, x, y)]`.
@@ -174,25 +175,44 @@ Differential(t)(u[2:n-1]) ~ SpectralApply(D2[2:n-1, :])(u[1:n]) - u[2:n-1] .^ 3
 Nonlinear terms broadcast over the slices, and nested derivative terms evaluate
 their argument on the whole direction before applying the outer operator, so
 `Differential(x)(a(u) * Differential(x)(u))` becomes
-`D1 * (a.(u) .* (D1 * u))` on slices. Boundary conditions on the faces of a 2D
-domain are array equations as well, so the number of symbolic equations is
-independent of the resolution in one and two dimensions. The differentiation
-matrices are held inside the operators rather than written into the expression
-tree, so the size of the generated code is independent of the resolution too.
-Systems with three or more spatial dimensions, stationary systems, and equations
-containing patterns without a slice form fall back to one scalar equation per grid
-point, each carrying a full differentiation row.
+`D1 * (a.(u) .* (D1 * u))` on slices. Boundary conditions on the faces of a
+multi-dimensional domain are array equations as well, so the number of symbolic
+equations is independent of the resolution in any number of spatial dimensions.
+The differentiation operators are held inside the `SpectralApply` terms rather than
+written into the expression tree, so the size of the symbolic expressions is
+independent of the resolution too. Stationary systems and equations containing
+patterns without a slice form fall back to one scalar equation per grid point,
+each carrying a full differentiation row.
 
-The `DAEProblem` returned by [`discretize`](@ref) keeps this array form.
-`mtkcompile` scalarizes it into one equation per unknown, each referencing the
-shared matrix products, which the generated code evaluates once per call.
+The `DAEProblem` returned by [`discretize`](@ref) keeps this array form at the
+`System` level. ModelingToolkit's code generation then scalarizes the residual into
+one entry per unknown, each referencing the shared derivative terms, which the
+generated code evaluates once per call; the compile time therefore still grows
+with the resolution, as it does for `MOLFiniteDifference` (see
+[MethodOfLines.jl#691](https://github.com/SciML/MethodOfLines.jl/issues/691)).
 
-At run time each derivative costs a dense matrix product: `O(n^2)` per
-application in one dimension and `O(n^2 m + n m^2)` on an `n × m` grid. This is
-the same cost as the handwritten benchmark implementations. The Jacobian is dense.
-For a few hundred nodes per direction this is fast; for larger periodic problems an
-FFT-based operator would be `O(n log n)`, which this discretization does not
-provide.
+At run time each Chebyshev derivative costs a dense matrix product: `O(n^2)` per
+application in one dimension and `O(n^2 m)` along the first axis of an `n × m`
+grid. This is the same cost as the handwritten benchmark implementations. The
+Jacobian is dense.
+
+## [FFT derivatives](@id pseudospectral-fft)
+
+Loading an `AbstractFFTs` backend, in practice
+
+```julia
+using FFTW
+```
+
+activates the `MethodOfLinesAbstractFFTsExt` extension. From then on every
+`FourierCollocation` direction applies whole-direction derivatives in the array
+form as `irfft((ik)^d .* rfft(u))` along that axis, with the Nyquist mode zeroed
+so that the result equals the dense matrix `D1^d` to roundoff, at `O(n log n)`
+instead of `O(n^2)` per application. FFT plans are created on first use and cached
+per array size. Jacobian evaluations through dual numbers, boundary rows and
+pinned single rows still use the dense matrix, which is kept alongside the FFT
+operator. `FourierCollocation(n; fft = false)` opts a direction out. Chebyshev
+directions always use the dense matrix.
 
 ## Limitations
 
@@ -202,5 +222,6 @@ provide.
 - There is no upwinding or scheme selection: all derivative orders in a direction
   share the same spectral differentiation matrix. Discontinuous solutions produce
   Gibbs oscillations, as with any global spectral method.
-- Derivatives are dense, so the number of nodes per direction should stay in the
-  hundreds.
+- Chebyshev derivatives are dense matrix products, so the number of Chebyshev nodes
+  per direction should stay in the hundreds. Fourier directions with an FFT backend
+  scale to much larger `n`, but the Jacobian remains dense.

--- a/docs/src/pseudospectral.md
+++ b/docs/src/pseudospectral.md
@@ -1,41 +1,16 @@
 # [Pseudospectral Discretization](@id pseudospectral)
 
-```julia
-struct PseudospectralDiscretization <: AbstractEquationSystemDiscretization
-    dxs::Any
-    time::Any
-    kwargs::Any
-end
-```
-
 `PseudospectralDiscretization` discretizes a `PDESystem` by collocation on spectral
 grids. The unknowns are the values of each dependent variable at the collocation
 nodes, exactly as for [`MOLFiniteDifference`](@ref molfd); the difference is the
-derivative approximation. Every spatial derivative `Differential(x)^d` is replaced by
-the dense differentiation matrix of the spectral interpolant through the nodes in
-that direction, so a derivative at one node involves the values at all nodes of the
-direction rather than a fixed stencil. Nonlinear terms are evaluated pointwise on
-the grid. The discretization works entirely in physical (grid) space: the unknowns
-are never transformed to spectral coefficients. For a periodic direction the
-derivative is `irfft((ik)^d .* rfft(u))` when an `AbstractFFTs` backend such as
-`FFTW` is loaded, and the equivalent dense trigonometric differentiation matrix
-otherwise; see [FFT derivatives](@ref pseudospectral-fft).
-
-This is the collocation family used by the SciMLBenchmarks
-`SimpleHandwrittenPDE` spectral work-precision benchmarks
-([Allen–Cahn](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/allen_cahn_spectral_wpd/),
-[Burgers](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/burgers_spectral_wpd/),
-[KdV](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/kdv_spectral_wpd/) and
-[Kuramoto–Sivashinsky](https://docs.sciml.ai/SciMLBenchmarksOutput/stable/SimpleHandwrittenPDE/ks_spectral_wpd/)),
-which also apply dense differentiation matrices in grid space. The periodic
-benchmarks convert the `SummationByPartsOperators` Fourier operator to the same
-dense matrix `FourierCollocation` builds. The non-periodic benchmarks use
-rectangular collocation from `ClassicalOrthogonalPolynomials` (the equation is
-imposed on `n - 2` first-kind Chebyshev points and mapped back through a
-resampling mass matrix), whereas `ChebyshevCollocation` uses square
-Chebyshev–Lobatto collocation with the boundary rows replaced by the boundary
-conditions, as in Trefethen's *Spectral Methods in MATLAB*. Both are spectrally
-accurate; the discrete operators are not identical.
+derivative approximation. Every spatial derivative `Differential(x)^d` is the
+derivative of the spectral interpolant through the nodes in that direction, so a
+derivative at one node involves the values at all nodes of the direction rather
+than a fixed stencil. Nonlinear terms are evaluated pointwise on the grid, and the
+unknowns stay in physical (grid) space. With an `AbstractFFTs` backend such as
+`FFTW` loaded, derivatives are applied with FFTs in both Fourier and Chebyshev
+directions; otherwise the equivalent dense differentiation matrix is used. See
+[FFT derivatives](@ref pseudospectral-fft).
 
 ```julia
 eq = [your system of equations, see examples for possibilities]
@@ -56,6 +31,8 @@ collocation specification:
   Chebyshev–Lobatto points `x_k = a + (b - a)/2 * (1 - cos(π(k - 1)/(n - 1)))`,
   which include both endpoints. Derivatives are those of the degree `n - 1`
   polynomial interpolant. Use for non-periodic directions.
+  `ChebyshevCollocation(n; fft = false)` keeps the dense matrix even when an FFT
+  backend is loaded.
 - `x => FourierCollocation(n)`: discretize `x` on `n` distinct equispaced points
   of the periodic interval `[a, b)`. Derivatives are those of the trigonometric
   interpolant. A periodic boundary condition `u(t, a) ~ u(t, b)` is required for
@@ -191,10 +168,9 @@ generated code evaluates once per call; the compile time therefore still grows
 with the resolution, as it does for `MOLFiniteDifference` (see
 [MethodOfLines.jl#691](https://github.com/SciML/MethodOfLines.jl/issues/691)).
 
-At run time each Chebyshev derivative costs a dense matrix product: `O(n^2)` per
+Without an FFT backend each derivative costs a dense matrix product: `O(n^2)` per
 application in one dimension and `O(n^2 m)` along the first axis of an `n × m`
-grid. This is the same cost as the handwritten benchmark implementations. The
-Jacobian is dense.
+grid. The Jacobian is dense either way.
 
 ## [FFT derivatives](@id pseudospectral-fft)
 
@@ -204,15 +180,27 @@ Loading an `AbstractFFTs` backend, in practice
 using FFTW
 ```
 
-activates the `MethodOfLinesAbstractFFTsExt` extension. From then on every
-`FourierCollocation` direction applies whole-direction derivatives in the array
-form as `irfft((ik)^d .* rfft(u))` along that axis, with the Nyquist mode zeroed
-so that the result equals the dense matrix `D1^d` to roundoff, at `O(n log n)`
-instead of `O(n^2)` per application. FFT plans are created on first use and cached
-per array size. Jacobian evaluations through dual numbers, boundary rows and
-pinned single rows still use the dense matrix, which is kept alongside the FFT
-operator. `FourierCollocation(n; fft = false)` opts a direction out. Chebyshev
-directions always use the dense matrix.
+activates the `MethodOfLinesAbstractFFTsExt` extension. From then on the
+whole-direction derivatives of the array form are applied with FFTs along their
+axis, at `O(n log n)` instead of `O(n^2)` per application:
+
+- `FourierCollocation`: `irfft((ik)^d .* rfft(u))`, with the Nyquist mode zeroed so
+  that the result equals the dense matrix `D1^d` to roundoff.
+- `ChebyshevCollocation`: the Chebyshev transform. The DCT-I of each line is the
+  real FFT of its even extension, the derivative's Chebyshev coefficients follow
+  from the backward recurrence `b[k-1] = b[k+1] + 2k a[k]` applied `d` times, and
+  the same transform maps the coefficients back to the nodes. This equals the
+  polynomial-interpolant differentiation matrix to roundoff. The derivative is
+  computed on every node, and the interior equation keeps the interior rows by
+  slicing; the boundary rows are what the boundary conditions replace.
+
+The Chebyshev transform of `n` nodes is a real FFT of length `2(n - 1)`, so
+`n = 2^k + 1` gives the fastest transforms. FFT plans are created on first use and
+cached per array size. Jacobian evaluations
+through dual numbers, boundary rows in boundary conditions and pinned single rows
+use the dense matrix, which is kept alongside the FFT operator.
+`ChebyshevCollocation(n; fft = false)` and `FourierCollocation(n; fft = false)` opt
+a direction out; custom node vectors always use the dense matrix.
 
 ## Limitations
 
@@ -222,6 +210,5 @@ directions always use the dense matrix.
 - There is no upwinding or scheme selection: all derivative orders in a direction
   share the same spectral differentiation matrix. Discontinuous solutions produce
   Gibbs oscillations, as with any global spectral method.
-- Chebyshev derivatives are dense matrix products, so the number of Chebyshev nodes
-  per direction should stay in the hundreds. Fourier directions with an FFT backend
-  scale to much larger `n`, but the Jacobian remains dense.
+- The Jacobian is dense, so implicit time stepping costs `O(n^3)` per factorization
+  in one dimension regardless of how the derivatives are applied.

--- a/ext/MethodOfLinesAbstractFFTsExt.jl
+++ b/ext/MethodOfLinesAbstractFFTsExt.jl
@@ -1,0 +1,63 @@
+module MethodOfLinesAbstractFFTsExt
+
+using MethodOfLines: MethodOfLines, FourierCollocation, apply_along
+using AbstractFFTs: AbstractFFTs, plan_rfft, plan_irfft
+
+"""
+    FourierFFTDerivative
+
+Whole-direction Fourier derivative applied with real FFTs: `irfft(mult .* rfft(X))`
+along one axis, with `mult = (i k)^d` over the `rfft` modes and the Nyquist mode
+zeroed, which is the mode-space form of the dense matrix `D1^d`. `mat` is that
+matrix, used for element types the FFT plans do not cover (dual numbers during
+Jacobian evaluation). Plans are cached per array size and axis.
+"""
+struct FourierFFTDerivative{T, M <: AbstractMatrix{T}}
+    n::Int
+    mult::Vector{Complex{T}}
+    mat::M
+    plans::Dict{Any, Any}
+end
+
+function MethodOfLines.fast_fourier_operator(spec::FourierCollocation, grid, d, mat)
+    n = spec.n
+    T = float(eltype(grid))
+    try
+        plan_rfft(zeros(T, n))
+    catch e
+        e isa InterruptException && rethrow(e)
+        @debug "No AbstractFFTs backend available for $(typeof(mat)); using the dense Fourier differentiation matrix." exception = e
+        return nothing
+    end
+    L = T(grid[end] - grid[1])
+    k = (2 * T(π) / L) .* (0:(n ÷ 2))
+    mult = (im .* k) .^ d
+    iseven(n) && (mult[end] = 0)
+    return FourierFFTDerivative{T, typeof(mat)}(n, mult, mat, Dict{Any, Any}())
+end
+
+function fft_plans!(op::FourierFFTDerivative{T}, X, J) where {T}
+    key = (size(X), J)
+    return get!(op.plans, key) do
+        p = plan_rfft(X, J)
+        Xh = p * X
+        (p, plan_irfft(Xh, op.n, J))
+    end
+end
+
+function MethodOfLines.apply_along(
+        op::FourierFFTDerivative{T}, X::AbstractArray{T, N}, ::Val{J}
+    ) where {T, N, J}
+    size(X, J) == op.n || return apply_along(op.mat, X, Val(J))
+    p, pinv = fft_plans!(op, X, J)
+    Xh = p * X
+    shape = ntuple(i -> i == J ? length(op.mult) : 1, N)
+    Xh .*= reshape(op.mult, shape)
+    return pinv * Xh
+end
+
+function MethodOfLines.apply_along(op::FourierFFTDerivative, X::AbstractArray, ::Val{J}) where {J}
+    return apply_along(op.mat, X, Val(J))
+end
+
+end

--- a/ext/MethodOfLinesAbstractFFTsExt.jl
+++ b/ext/MethodOfLinesAbstractFFTsExt.jl
@@ -1,7 +1,19 @@
 module MethodOfLinesAbstractFFTsExt
 
-using MethodOfLines: MethodOfLines, FourierCollocation, apply_along
+using MethodOfLines: MethodOfLines, ChebyshevCollocation, FourierCollocation, apply_along
 using AbstractFFTs: AbstractFFTs, plan_rfft, plan_irfft
+using LinearAlgebra: mul!
+
+function has_fft_backend(T, n)
+    try
+        plan_rfft(zeros(T, n))
+        return true
+    catch e
+        e isa InterruptException && rethrow(e)
+        @debug "No AbstractFFTs backend available; using the dense differentiation matrix." exception = e
+        return false
+    end
+end
 
 """
     FourierFFTDerivative
@@ -19,16 +31,10 @@ struct FourierFFTDerivative{T, M <: AbstractMatrix{T}}
     plans::Dict{Any, Any}
 end
 
-function MethodOfLines.fast_fourier_operator(spec::FourierCollocation, grid, d, mat)
+function MethodOfLines.fast_spectral_operator(spec::FourierCollocation, grid, d, mat)
     n = spec.n
     T = float(eltype(grid))
-    try
-        plan_rfft(zeros(T, n))
-    catch e
-        e isa InterruptException && rethrow(e)
-        @debug "No AbstractFFTs backend available for $(typeof(mat)); using the dense Fourier differentiation matrix." exception = e
-        return nothing
-    end
+    has_fft_backend(T, n) || return nothing
     L = T(grid[end] - grid[1])
     k = (2 * T(π) / L) .* (0:(n ÷ 2))
     mult = (im .* k) .^ d
@@ -36,12 +42,13 @@ function MethodOfLines.fast_fourier_operator(spec::FourierCollocation, grid, d, 
     return FourierFFTDerivative{T, typeof(mat)}(n, mult, mat, Dict{Any, Any}())
 end
 
-function fft_plans!(op::FourierFFTDerivative{T}, X, J) where {T}
-    key = (size(X), J)
-    return get!(op.plans, key) do
+# Plans and buffers for one array size and axis: the forward plan, the inverse plan and
+# the mode-space buffer. Shared across calls, so not safe for concurrent evaluation.
+function fft_workspace!(op::FourierFFTDerivative, X, J)
+    return get!(op.plans, (size(X), J)) do
         p = plan_rfft(X, J)
         Xh = p * X
-        (p, plan_irfft(Xh, op.n, J))
+        (p, plan_irfft(Xh, op.n, J), Xh)
     end
 end
 
@@ -49,14 +56,127 @@ function MethodOfLines.apply_along(
         op::FourierFFTDerivative{T}, X::AbstractArray{T, N}, ::Val{J}
     ) where {T, N, J}
     size(X, J) == op.n || return apply_along(op.mat, X, Val(J))
-    p, pinv = fft_plans!(op, X, J)
-    Xh = p * X
+    p, pinv, Xh = fft_workspace!(op, X, J)
+    mul!(Xh, p, X)
     shape = ntuple(i -> i == J ? length(op.mult) : 1, N)
     Xh .*= reshape(op.mult, shape)
-    return pinv * Xh
+    Y = similar(X)
+    mul!(Y, pinv, Xh)
+    return Y
 end
 
-function MethodOfLines.apply_along(op::FourierFFTDerivative, X::AbstractArray, ::Val{J}) where {J}
+"""
+    ChebyshevFFTDerivative
+
+Whole-direction Chebyshev derivative on `n` Lobatto nodes through the Chebyshev
+transform: the DCT-I of a line is the real FFT of its even extension, the
+coefficients of the derivative follow from the backward recurrence
+`b[k-1] = b[k+1] + 2k a[k]`, applied `order` times, and the same transform maps the
+coefficients back to nodal values. `scale` carries the map from `[-1, 1]` to the
+domain. Equivalent to the dense matrix `mat`, which is used for element types the
+FFT plans do not cover. Plans are cached per array size and axis.
+"""
+struct ChebyshevFFTDerivative{T, M <: AbstractMatrix{T}}
+    n::Int
+    order::Int
+    scale::T
+    mat::M
+    plans::Dict{Any, Any}
+end
+
+function MethodOfLines.fast_spectral_operator(spec::ChebyshevCollocation, grid, d, mat)
+    n = spec.n
+    n >= 3 || return nothing
+    T = float(eltype(grid))
+    has_fft_backend(T, 2 * (n - 1)) || return nothing
+    scale = (-2 / T(grid[end] - grid[1]))^d
+    return ChebyshevFFTDerivative{T, typeof(mat)}(n, d, scale, mat, Dict{Any, Any}())
+end
+
+# Writes the even (mirror) extension of `X` along axis `J` into `V`: `n` nodes become
+# `2(n - 1)` samples of one period, so a real FFT along `J` is the DCT-I of each line.
+function even_extension!(V, X, J)
+    sz = size(X)
+    n = sz[J]
+    nb = prod(sz[1:(J - 1)])
+    na = prod(sz[(J + 1):end])
+    Xr = reshape(X, nb, n, na)
+    Vr = reshape(V, nb, 2 * (n - 1), na)
+    @inbounds for a in 1:na
+        for k in 1:n, b in 1:nb
+            Vr[b, k, a] = Xr[b, k, a]
+        end
+        for k in 1:(n - 2), b in 1:nb
+            Vr[b, n + k, a] = Xr[b, n - k, a]
+        end
+    end
+    return V
+end
+
+# Plan and buffers for one array size and axis: the extension `V`, its transform `U`,
+# the coefficient array `A` and two lines for the recurrence. Shared across calls, so
+# not safe for concurrent evaluation.
+function fft_workspace!(op::ChebyshevFFTDerivative{T}, X::AbstractArray{T, N}, J) where {T, N}
+    return get!(op.plans, (size(X), J)) do
+        sz = size(X)
+        V = zeros(T, ntuple(i -> i == J ? 2 * (sz[J] - 1) : sz[i], N))
+        p = plan_rfft(V, J)
+        (p, V, p * V, zeros(T, sz), zeros(T, sz[J]), zeros(T, sz[J]))
+    end
+end
+
+# Coefficients of the derivative of `a`, both in the double-prime convention (first
+# and last entries doubled), written into `out`.
+function chebyshev_derivative_coefficients!(out::AbstractVector, a::AbstractVector)
+    N = length(a) - 1
+    out[N + 1] = 0
+    out[N] = N * a[N + 1]
+    @inbounds for k in (N - 1):-1:1
+        out[k] = out[k + 2] + 2k * a[k + 1]
+    end
+    return out
+end
+
+# Applies the recurrence `order` times to every line along axis `J` of `A`, in place.
+function chebyshev_derivative_coefficients!(A::AbstractArray, J, order, line, tmp)
+    sz = size(A)
+    nb = prod(sz[1:(J - 1)])
+    na = prod(sz[(J + 1):end])
+    Ar = reshape(A, nb, sz[J], na)
+    @inbounds for a in 1:na, b in 1:nb
+        for k in 1:sz[J]
+            line[k] = Ar[b, k, a]
+        end
+        for _ in 1:order
+            chebyshev_derivative_coefficients!(tmp, line)
+            line, tmp = tmp, line
+        end
+        for k in 1:sz[J]
+            Ar[b, k, a] = line[k]
+        end
+    end
+    return A
+end
+
+function MethodOfLines.apply_along(
+        op::ChebyshevFFTDerivative{T}, X::AbstractArray{T, N}, ::Val{J}
+    ) where {T, N, J}
+    size(X, J) == op.n || return apply_along(op.mat, X, Val(J))
+    p, V, U, A, line, tmp = fft_workspace!(op, X, J)
+    even_extension!(V, X, J)
+    mul!(U, p, V)
+    A .= real.(U) ./ (op.n - 1)
+    chebyshev_derivative_coefficients!(A, J, op.order, line, tmp)
+    even_extension!(V, A, J)
+    mul!(U, p, V)
+    Y = similar(X)
+    Y .= real.(U) .* (op.scale / 2)
+    return Y
+end
+
+function MethodOfLines.apply_along(
+        op::Union{FourierFFTDerivative, ChebyshevFFTDerivative}, X::AbstractArray, ::Val{J}
+    ) where {J}
     return apply_along(op.mat, X, Val(J))
 end
 

--- a/src/MOL_discretization.jl
+++ b/src/MOL_discretization.jl
@@ -140,7 +140,7 @@ end
 Generate an expression for the ODE function produced by method-of-lines discretization.
 """
 function ODEFunctionExpr(
-        pdesys::PDESystem, discretization::MethodOfLines.MOLFiniteDifference
+        pdesys::PDESystem, discretization::MethodOfLines.MOLDiscretization
     )
     sys, tspan = SciMLBase.symbolic_discretize(pdesys, discretization)
     return try
@@ -161,7 +161,7 @@ function ODEFunctionExpr(
 end
 
 function SciMLBase.ODEFunction(
-        pdesys::PDESystem, discretization::MethodOfLines.MOLFiniteDifference;
+        pdesys::PDESystem, discretization::MethodOfLines.MOLDiscretization;
         analytic = nothing, kwargs...
     )
     sys, tspan = SciMLBase.symbolic_discretize(pdesys, discretization)
@@ -199,7 +199,7 @@ end
 Write generated discretized ODE function code for `pdesys` to `filename`.
 """
 function generate_code(
-        pdesys::PDESystem, discretization::MethodOfLines.MOLFiniteDifference,
+        pdesys::PDESystem, discretization::MethodOfLines.MOLDiscretization,
         filename = "generated_code_of_pdesys.jl"
     )
     code = ODEFunctionExpr(pdesys, discretization)
@@ -242,7 +242,7 @@ sol = solve(prob, Tsit5())
 ```
 """
 function SciMLBase.discretize(
-        pdesys::PDESystem, discretization::MOLFiniteDifference;
+        pdesys::PDESystem, discretization::MOLDiscretization;
         analytic = nothing, checks = true, fallback = true, kwargs...
     )
     sys, tspan = SciMLBase.symbolic_discretize(pdesys, discretization; checks = checks)
@@ -262,7 +262,7 @@ function SciMLBase.discretize(
     return _ode_problem(sys, tspan, pdesys, discretization; analytic, kwargs...)
 end
 
-function _stationary_problem(sys, discretization::MOLFiniteDifference; kwargs...)
+function _stationary_problem(sys, discretization::MOLDiscretization; kwargs...)
     simpsys = mtkcompile(sys)
     PDEBase.add_metadata!(getmetadata(sys, ModelingToolkit.ProblemTypeCtx, nothing), sys)
     u0_guess = Dict(u => 1.0 for u in get_unknowns(simpsys))
@@ -272,7 +272,7 @@ function _stationary_problem(sys, discretization::MOLFiniteDifference; kwargs...
 end
 
 function _ode_problem(
-        sys, tspan, pdesys, discretization::MOLFiniteDifference; analytic = nothing,
+        sys, tspan, pdesys, discretization::MOLDiscretization; analytic = nothing,
         kwargs...
     )
     simpsys = mtkcompile(sys)

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -83,6 +83,7 @@ include("interface/grid_types.jl")
 include("interface/scheme_types.jl")
 include("interface/callbacks.jl")
 include("interface/MOLFiniteDifference.jl")
+include("interface/PseudospectralDiscretization.jl")
 
 include("discretization/discretize_vars.jl")
 include("MOL_utils.jl")
@@ -122,6 +123,7 @@ include("discretization/schemes/spherical_laplacian/spherical_laplacian.jl")
 include("discretization/schemes/WENO/nonuniform_weno.jl")
 include("discretization/schemes/WENO/WENO.jl")
 include("discretization/schemes/integral_expansion/integral_expansion.jl")
+include("discretization/schemes/pseudospectral/pseudospectral.jl")
 
 # System Discretization
 include("discretization/generate_finite_difference_rules.jl")
@@ -131,6 +133,7 @@ include("discretization/staggered_discretize.jl")
 
 # Main
 include("discretization/discretize_equations.jl")
+include("discretization/pseudospectral_discretize.jl")
 include("dae_discretization.jl")
 include("MOL_discretization.jl")
 
@@ -138,7 +141,8 @@ include("MOL_discretization.jl")
 include("precompile.jl")
 
 # Export
-export MOLFiniteDifference, discretize, symbolic_discretize, ODEFunctionExpr, generate_code,
+export MOLFiniteDifference, PseudospectralDiscretization, ChebyshevCollocation,
+    FourierCollocation, discretize, symbolic_discretize, ODEFunctionExpr, generate_code,
     edge_align, center_align, get_discrete, chebyspace
 export UpwindScheme, WENOScheme, FunctionalScheme, MOLDiscCallback
 

--- a/src/MethodOfLines.jl
+++ b/src/MethodOfLines.jl
@@ -1,6 +1,6 @@
 module MethodOfLines
 import LinearAlgebra
-using LinearAlgebra: I, cond, dot
+using LinearAlgebra: I, cond, dot, diag, diagind
 import SciMLBase
 using SciMLBase: DAEProblem, NonlinearProblem, ODEFunction, ODEProblem, SplitODEProblem
 import DiffEqBase

--- a/src/dae_discretization.jl
+++ b/src/dae_discretization.jl
@@ -190,7 +190,7 @@ produces, so it is indexed and interpolated by the `PDESystem`'s own variables:
 `sol[u(t, x)]`, `sol(t, x)`.
 """
 function SciMLBase.DAEProblem(
-        pdesys::PDESystem, discretization::MOLFiniteDifference;
+        pdesys::PDESystem, discretization::MOLDiscretization;
         initializealg = nothing, build_initializeprob = false, kwargs...
     )
     sys, tspan = SciMLBase.symbolic_discretize(pdesys, discretization)
@@ -214,7 +214,7 @@ Build the `DAEProblem` from an already discretized system. Shared by
 system is discretized once.
 """
 function _dae_problem(
-        sys, tspan, discretization::MOLFiniteDifference;
+        sys, tspan, discretization::MOLDiscretization;
         initializealg = nothing, build_initializeprob = false, kwargs...
     )
     sys = complete(sys)

--- a/src/discretization/discretize_equations.jl
+++ b/src/discretization/discretize_equations.jl
@@ -3166,21 +3166,9 @@ function array_bc_eqs(s, boundary, interiormap, derivweights, bcmap)
     for d in derivweights.orders[x_]
         Dop = get(derivweights.map, Differential(x_)^d, nothing)
         Dop === nothing && continue
-        ws, Itap = try
-            central_difference_weights_and_stencil(
-                Dop, II0, s, filter_interfaces(bcmap[operation(u)][x_]), (j, x_), u
-            )
-        catch e
-            e isa InterruptException && rethrow(e)
-            throw(ArrayFormFallback("could not build boundary stencil for order $d"))
-        end
-        offsets = [I[j] - II0[j] for I in Itap]
-        all(I -> all(k -> k == j || I[k] == II0[k], 1:N), Itap) ||
-            throw(ArrayFormFallback("boundary stencil is not axis aligned"))
-        slices = [
-            array_slice(u, s, ranges, indexmap; shiftx = x_, offset = o) for o in offsets
-        ]
-        expr = array_stencil(collect(ws), slices)
+        expr = array_boundary_derivative_expr(
+            Dop, II0, s, u, x_, j, N, ranges, indexmap, bcmap
+        )
         for v in bcdepvars
             isequal(depvar(v, s), u) || continue
             push!(derivrules, safe_unwrap((Differential(x_)^d)(v)) => expr)
@@ -3228,6 +3216,35 @@ function array_bc_eqs(s, boundary, interiormap, derivweights, bcmap)
         throw(ArrayFormFallback("boundary condition has no discretizable terms"))
     end
     return [lhs ~ rhs]
+end
+
+"""
+The slice form of `Dop` applied to `u` on the face at `II0`, for the boundary
+direction `x_` (equation axis `j` of `N`): the weights and taps the pointwise path
+would use at a representative point on the face, with the taps as shifted slices.
+"""
+function array_boundary_derivative_expr(
+        Dop, II0, s, u, x_, j, N, ranges, indexmap, bcmap
+    )
+    ws, Itap = try
+        central_difference_weights_and_stencil(
+            Dop, II0, s, filter_interfaces(bcmap[operation(u)][x_]), (j, x_), u
+        )
+    catch e
+        e isa InterruptException && rethrow(e)
+        throw(
+            ArrayFormFallback(
+                "could not build boundary stencil for order $(Dop.derivative_order)"
+            )
+        )
+    end
+    offsets = [I[j] - II0[j] for I in Itap]
+    all(I -> all(k -> k == j || I[k] == II0[k], 1:N), Itap) ||
+        throw(ArrayFormFallback("boundary stencil is not axis aligned"))
+    slices = [
+        array_slice(u, s, ranges, indexmap; shiftx = x_, offset = o) for o in offsets
+    ]
+    return array_stencil(collect(ws), slices)
 end
 
 """

--- a/src/discretization/generate_ic_defaults.jl
+++ b/src/discretization/generate_ic_defaults.jl
@@ -1,5 +1,5 @@
 function PDEBase.generate_ic_defaults(
-        tconds, s::DiscreteSpace, ::MOLFiniteDifference
+        tconds, s::DiscreteSpace, ::MOLDiscretization
     )
     t = s.time
     if s.time !== nothing

--- a/src/discretization/pseudospectral_discretize.jl
+++ b/src/discretization/pseudospectral_discretize.jl
@@ -1,0 +1,193 @@
+# `PseudospectralDiscretization` pipeline.
+#
+# The parsing, boundary-condition and system-construction machinery is shared
+# with `MOLFiniteDifference`; the differences are confined to grid
+# construction (`construct_discrete_space`), the derivative operators
+# (`construct_differential_discretizer`), interior sizing (no ghost-point
+# padding: spectral rows always span the whole direction, and higher-order
+# periodic matching conditions are redundant), and the rule generation
+# (`generate_finite_difference_rules`).
+
+function PDEBase.interface_errors(
+        pdesys::PDESystem, v::PDEBase.VariableMap, discretization::PseudospectralDiscretization
+    )
+    for x in v.x̄
+        @assert haskey(discretization.dxs, Num(x))||haskey(discretization.dxs, x) "Variable $x has no collocation specification"
+    end
+    return
+end
+
+function PDEBase.check_boundarymap(
+        boundarymap, v::PDEBase.VariableMap, discretization::PseudospectralDiscretization
+    )
+    bs = flatten_vardict(boundarymap)
+    for b in bs
+        if b isa Union{InterfaceBoundary, HigherOrderInterfaceBoundary}
+            isequal(b.x, b.x2) || throw(
+                ArgumentError(
+                    "PseudospectralDiscretization does not yet support multi-domain interface boundary conditions like $(b.eq), only same-variable periodic conditions are supported."
+                )
+            )
+        end
+    end
+    for x in v.x̄
+        spec = discretization.dxs[x]
+        for uop in keys(boundarymap)
+            ubs = boundarymap[uop][x]
+            hasperiodic = any(
+                b -> b isa Union{InterfaceBoundary, HigherOrderInterfaceBoundary}, ubs
+            )
+            hastruncating = any(
+                b -> b isa AbstractTruncatingBoundary &&
+                    !(b isa Union{InterfaceBoundary, HigherOrderInterfaceBoundary}), ubs
+            )
+            if spec isa FourierCollocation
+                hasperiodic || throw(
+                    ArgumentError(
+                        "`FourierCollocation` for $x requires a periodic boundary condition `u(t, a) ~ u(t, b)` on every dependent variable in that direction; none was found for $uop."
+                    )
+                )
+                hastruncating && throw(
+                    ArgumentError(
+                        "Periodic direction $x discretized with `FourierCollocation` does not accept additional truncating boundary conditions like $(first(filter(b -> b isa AbstractTruncatingBoundary && !(b isa Union{InterfaceBoundary, HigherOrderInterfaceBoundary}), ubs)).eq)."
+                    )
+                )
+            else
+                hasperiodic && throw(
+                    ArgumentError(
+                        "Direction $x has a periodic boundary condition but is discretized with $(spec isa AbstractVector ? "a custom grid" : string(typeof(spec))). Periodic directions require `x => FourierCollocation(n)`."
+                    )
+                )
+            end
+        end
+    end
+    return
+end
+
+function PDEBase.should_transform(
+        pdesys::PDESystem, disc::PseudospectralDiscretization, boundarymap
+    )
+    # The collocation evaluator handles nested derivative terms like
+    # `Dx(a(u) * Dx(u))` or `Dx(u^2)` natively, so the FD-oriented
+    # transformation (auxiliary variables etc.) is unnecessary.
+    return false
+end
+
+"""
+`spectral_clip_interior!!`: higher-order periodic matching conditions are
+satisfied identically by the trigonometric interpolant, so they must not
+truncate the interior - the corresponding equations are skipped in
+`discretize_equation!` as well.
+"""
+clip_interior!!(lower, upper, s, b, discretization) = clip_interior!!(lower, upper, s, b)
+function clip_interior!!(
+        lower, upper, s, b::HigherOrderInterfaceBoundary,
+        discretization::PseudospectralDiscretization
+    )
+    return nothing
+end
+
+function validate_interface_orders(
+        pdes, boundarymap, discretization::PseudospectralDiscretization
+    )
+    return nothing
+end
+
+"""
+No stencil extents: spectral rows always span the entire direction, so no
+ghost-point padding is ever required.
+"""
+function calculate_stencil_extents(
+        s, u, discretization::PseudospectralDiscretization, orders, bcmap
+    )
+    n = length(remove(arguments(u), s.time))
+    return zeros(Int, n), zeros(Int, n)
+end
+
+function PDEBase.construct_discrete_space(
+        vars::PDEBase.VariableMap, discretization::PseudospectralDiscretization
+    )
+    x̄ = vars.x̄
+    depvars = vars.ū
+    nspace = length(x̄)
+
+    axies = Dict(
+        map(x̄) do x
+            spec = discretization.dxs[x]
+            a, b = vars.intervals[x]
+            x => spectral_grid(spec, a, b)
+        end
+    )
+    grid = axies
+    dxs = Dict(x => diff(axies[x]) for x in x̄)
+
+    Iaxies = [
+        u => CartesianIndices(
+            (
+                (
+                    axes(axies[x])[1]
+                        for x in remove(arguments(u), vars.time)
+                )...,
+            )
+        )
+            for u in depvars
+    ]
+    depvarsdisc = discretize_dep_vars(depvars, grid, vars)
+
+    return DiscreteSpace{nspace, length(depvars), CenterAlignedGrid}(
+        vars, Dict(depvarsdisc), axies, grid, dxs, Dict(Iaxies), Dict(Iaxies), nothing
+    )
+end
+
+function PDEBase.discretize_equation!(
+        disc_state::PDEBase.EquationState, pde::Equation, interiormap,
+        eqvar, bcmap, depvars, s::DiscreteSpace,
+        derivweights::SpectralDifferentialDiscretizer, indexmap,
+        discretization::PseudospectralDiscretization
+    )
+    boundaryvalfuncs = generate_boundary_val_funcs(
+        s, depvars, bcmap, indexmap, derivweights
+    )
+    eqvarbcs = mapreduce(x -> bcmap[operation(eqvar)][x], vcat, s.x̄)
+    for boundary in eqvarbcs
+        if boundary isa HigherOrderInterfaceBoundary
+            # Periodic derivative matching is automatic for the trigonometric
+            # interpolant. Verify the condition is identically satisfied rather
+            # than emitting a redundant equation.
+            eqs = generate_bc_eqs(
+                s, boundaryvalfuncs, boundary, interiormap,
+                Dict(ivs(depvar(boundary.u, s), s) .=> eachindex(ivs(depvar(boundary.u, s), s)))
+            )
+            all(eq -> isequal(eq.lhs, eq.rhs), eqs) || throw(
+                ArgumentError(
+                    "Periodic boundary condition $(boundary.eq) is inconsistent with the `FourierCollocation` discretization: derivative matching is automatic for the trigonometric interpolant and cannot express a jump."
+                )
+            )
+            continue
+        end
+        generate_bc_eqs!(disc_state, s, boundaryvalfuncs, interiormap, boundary)
+    end
+    generate_corner_eqs!(disc_state, s, interiormap, pde)
+
+    interior = interiormap.I[pde]
+    if isempty(interior)
+        push!(
+            disc_state.eqs,
+            discretize_equation_at_point(
+                CartesianIndex(), s, depvars, pde, derivweights,
+                bcmap, eqvar, indexmap, boundaryvalfuncs
+            )
+        )
+    else
+        for II in interior
+            push!(
+                disc_state.eqs,
+                discretize_equation_at_point(
+                    II, s, depvars, pde, derivweights,
+                    bcmap, eqvar, indexmap, boundaryvalfuncs
+                )
+            )
+        end
+    end
+    return disc_state.eqs
+end

--- a/src/discretization/pseudospectral_discretize.jl
+++ b/src/discretization/pseudospectral_discretize.jl
@@ -145,18 +145,18 @@ end
 """
     SpectralApply{J, S}
 
-Symbolic array operator applying a differentiation block along axis `J` of its
-argument, producing an array of size `S`. The block is a field rather than a literal
-in the expression tree, so generated code references it as a constant instead of
-spelling out every entry.
+Symbolic array operator applying a differentiation operator (a dense block, or a
+whole-direction FFT operator) along axis `J` of its argument through
+[`apply_along`](@ref), producing an array of size `S`. The operator is a field
+rather than a literal in the expression tree, so generated code references it as a
+constant instead of spelling out every entry.
 """
-struct SpectralApply{J, S, M <: AbstractMatrix} <: Function
+struct SpectralApply{J, S, M} <: Function
     mat::M
 end
-SpectralApply{J, S}(mat::M) where {J, S, M <: AbstractMatrix} = SpectralApply{J, S, M}(mat)
+SpectralApply{J, S}(mat::M) where {J, S, M} = SpectralApply{J, S, M}(mat)
 
-(op::SpectralApply{1})(X) = op.mat * X
-(op::SpectralApply{2})(X) = X * transpose(op.mat)
+(op::SpectralApply{J})(X) where {J} = apply_along(op.mat, X, Val(J))
 
 function SymbolicUtils.promote_symtype(::SpectralApply{J, S}, ::Type) where {J, S}
     return Array{Real, length(S)}
@@ -174,7 +174,7 @@ end
 function spectral_apply_along(mat, j, X)
     Xu = safe_unwrap(X)
     sz = collect(size(Symbolics.wrap(Xu)))
-    sz[j] = size(mat, 1)
+    sz[j] = mat isa AbstractMatrix ? size(mat, 1) : sz[j]
     S = Tuple(sz)
     sh = SymbolicUtils.ShapeVecT(map(Base.UnitRange{Int} ∘ Base.OneTo, S))
     tm = SymbolicUtils.term(
@@ -284,6 +284,9 @@ function spectral_array_derivative(term, ranges, c::SpectralArrayContext)
         spectral_arrayify(inner, innerranges, c)
     end
     is_array_valued(val) || return 0
+    if D.fast !== nothing && rows == 1:size(D.mat, 1)
+        return spectral_apply_along(D.fast, j, val)
+    end
     return spectral_apply_along(D.mat[rows, :], j, val)
 end
 
@@ -292,8 +295,8 @@ end
 
 The interior of `pde` as a single symbolic array equation over the interior box, with
 each spatial derivative a dense differentiation block applied along its axis. Throws
-`ArrayFormFallback` for patterns without a slice form here: stationary systems, more
-than two spatial dimensions, and whatever `arrayify` declines.
+`ArrayFormFallback` for patterns without a slice form here: stationary systems and
+whatever `arrayify` declines.
 """
 function discretize_spectral_array_form(
         pde, interior, s, depvars, derivweights, eqvar, indexmap
@@ -305,9 +308,6 @@ function discretize_spectral_array_form(
     )
     args = ivs(eqvar, s)
     N = length(args)
-    N <= 2 || throw(
-        ArrayFormFallback("spectral slice form is limited to two spatial dimensions")
-    )
     array_validate_depvar_axes(pde, s, args)
     slicevars = array_sliceable_depvars(
         s, array_unique_depvars(array_pde_occurrences(pde, s), s), args

--- a/src/discretization/pseudospectral_discretize.jl
+++ b/src/discretization/pseudospectral_discretize.jl
@@ -5,8 +5,11 @@
 # construction (`construct_discrete_space`), the derivative operators
 # (`construct_differential_discretizer`), interior sizing (no ghost-point
 # padding: spectral rows always span the whole direction, and higher-order
-# periodic matching conditions are redundant), and the rule generation
-# (`generate_finite_difference_rules`).
+# periodic matching conditions are redundant), and equation generation. The
+# interior is emitted in slice form (`discretize_spectral_array_form`), with each
+# derivative a `SpectralApply` operator over the whole direction; boundary faces
+# reuse `array_bc_eqs`. Patterns without a slice form fall back to the pointwise
+# collocation rules in `schemes/pseudospectral/pseudospectral.jl`.
 
 function PDEBase.interface_errors(
         pdesys::PDESystem, v::PDEBase.VariableMap, discretization::PseudospectralDiscretization
@@ -139,6 +142,238 @@ function PDEBase.construct_discrete_space(
     )
 end
 
+"""
+    SpectralApply{J, S}
+
+Symbolic array operator applying a differentiation block along axis `J` of its
+argument, producing an array of size `S`. The block is a field rather than a literal
+in the expression tree, so generated code references it as a constant instead of
+spelling out every entry.
+"""
+struct SpectralApply{J, S, M <: AbstractMatrix} <: Function
+    mat::M
+end
+SpectralApply{J, S}(mat::M) where {J, S, M <: AbstractMatrix} = SpectralApply{J, S, M}(mat)
+
+(op::SpectralApply{1})(X) = op.mat * X
+(op::SpectralApply{2})(X) = X * transpose(op.mat)
+
+function SymbolicUtils.promote_symtype(::SpectralApply{J, S}, ::Type) where {J, S}
+    return Array{Real, length(S)}
+end
+
+function SymbolicUtils.promote_shape(
+        ::SpectralApply{J, S}, ::SymbolicUtils.ShapeT
+    ) where {J, S}
+    return SymbolicUtils.ShapeVecT(map(Base.UnitRange{Int} ∘ Base.OneTo, S))
+end
+
+"""
+`mat` applied along axis `j` of the symbolic array `X`, as a [`SpectralApply`](@ref) term.
+"""
+function spectral_apply_along(mat, j, X)
+    Xu = safe_unwrap(X)
+    sz = collect(size(Symbolics.wrap(Xu)))
+    sz[j] = size(mat, 1)
+    S = Tuple(sz)
+    sh = SymbolicUtils.ShapeVecT(map(Base.UnitRange{Int} ∘ Base.OneTo, S))
+    tm = SymbolicUtils.term(
+        SpectralApply{j, S}(mat), Xu; type = Array{Real, length(S)}, shape = sh
+    )
+    return Symbolics.wrap(tm)
+end
+
+"""
+Whether `ex` varies along `x`: `x` itself appears, or a dependent variable is called
+with `x` (rather than a literal) in that slot.
+"""
+function spectral_depends_on(ex, x, s)
+    array_mentions_iv(ex, x) && return true
+    xu = safe_unwrap(x)
+    for u_ in get_depvars(ex, s.vars.depvar_ops)
+        any(a -> isequal(safe_unwrap(a), xu), arguments(u_)) && return true
+    end
+    return false
+end
+
+struct SpectralArrayContext
+    s::Any
+    derivweights::Any
+    indexmap::Any
+    args::Any
+    depvars::Any
+    pde::Any
+end
+
+"""
+    spectral_arrayify(ex, ranges, c::SpectralArrayContext)
+
+The slice form of `ex` over the box `ranges` (equation axis => index range). Every
+outermost spatial-derivative subterm becomes a [`SpectralApply`](@ref) term via
+[`spectral_array_derivative`](@ref); everything else is handled by `arrayify` with
+the same slice, boundary-value, time-literal and grid rules the finite difference
+array form uses.
+"""
+function spectral_arrayify(ex, ranges, c::SpectralArrayContext)
+    s = c.s
+    N = length(c.args)
+    dterms = Any[]
+    find_diff_terms!(dterms, safe_unwrap(ex), s.x̄)
+    diffrules = Pair[
+        tm => spectral_array_derivative(tm, ranges, c) for tm in unique!(dterms)
+    ]
+    bvalrules = array_boundary_value_rules(c.pde, s, ranges, c.indexmap, c.derivweights)
+    tlrules = array_time_literal_rules(c.pde, s, ranges, c.indexmap, c.derivweights)
+    varrules = Pair[]
+    for u in c.depvars
+        if isempty(ivs(u, s))
+            push!(varrules, safe_unwrap(u) => array_scalar_discvar(u, s))
+        else
+            push!(varrules, safe_unwrap(u) => array_slice(u, s, ranges, c.indexmap))
+        end
+    end
+    gridrules = Pair[
+        safe_unwrap(x) => array_grid_vals(x, s, ranges, c.indexmap, N) for x in c.args
+    ]
+    ctx = ArrayifyContext(
+        vcat(diffrules, bvalrules, tlrules, varrules, gridrules), s.time
+    )
+    return arrayify(ex, ctx)
+end
+
+"""
+    spectral_array_derivative(term, ranges, c::SpectralArrayContext)
+
+`(Differential(x)^d)(inner)` over `ranges` as the differentiation block for the rows
+of `ranges` along `x` applied to `inner` evaluated on the full tap range of that
+direction. A dependent variable call with a literal argument pins that axis: a literal
+in the `x` slot selects the boundary row (`Dx(u(t, a, y))`), a literal elsewhere
+restricts the slice (`Dx(u(t, x, b))`). Terms that do not vary along `x` differentiate
+to zero.
+"""
+function spectral_array_derivative(term, ranges, c::SpectralArrayContext)
+    s = c.s
+    op = operation(term)
+    x = op.x
+    inner = only(arguments(term))
+    haskey(c.indexmap, x) || throw(
+        ArrayFormFallback("derivative in $x, which is not an axis of the equation")
+    )
+    j = c.indexmap[x]
+    D = c.derivweights.map[Differential(x)^op.order]
+    innerranges = copy(ranges)
+    innerranges[j] = first(D.taps):last(D.taps)
+    rows = D.rowmap[ranges[j]]
+    val = if iscall(inner) && any(o -> isequal(operation(inner), o), s.vars.depvar_ops)
+        u = depvar(inner, s)
+        uivs = ivs(u, s)
+        any(y -> isequal(y, x), uivs) || return 0
+        for (y, a) in zip(uivs, remove(arguments(inner), s.time))
+            aval = unwrap_const(safe_unwrap(a))
+            aval isa Number || continue
+            idx = array_boundary_edge_index(aval, y, s)
+            if isequal(y, x)
+                rows = D.rowmap[idx:idx]
+            else
+                innerranges[c.indexmap[y]] = idx:idx
+            end
+        end
+        array_slice(u, s, innerranges, c.indexmap)
+    else
+        spectral_depends_on(inner, x, s) || return 0
+        spectral_arrayify(inner, innerranges, c)
+    end
+    is_array_valued(val) || return 0
+    return spectral_apply_along(D.mat[rows, :], j, val)
+end
+
+"""
+    discretize_spectral_array_form(pde, interior, s, depvars, derivweights, eqvar, indexmap)
+
+The interior of `pde` as a single symbolic array equation over the interior box, with
+each spatial derivative a dense differentiation block applied along its axis. Throws
+`ArrayFormFallback` for patterns without a slice form here: stationary systems, more
+than two spatial dimensions, and whatever `arrayify` declines.
+"""
+function discretize_spectral_array_form(
+        pde, interior, s, depvars, derivweights, eqvar, indexmap
+    )
+    s.time === nothing && throw(
+        ArrayFormFallback(
+            "stationary (no time) systems have no array form in NonlinearSystem construction"
+        )
+    )
+    args = ivs(eqvar, s)
+    N = length(args)
+    N <= 2 || throw(
+        ArrayFormFallback("spectral slice form is limited to two spatial dimensions")
+    )
+    array_validate_depvar_axes(pde, s, args)
+    slicevars = array_sliceable_depvars(
+        s, array_unique_depvars(array_pde_occurrences(pde, s), s), args
+    )
+    lo = Tuple(first(interior))
+    hi = Tuple(last(interior))
+    length(interior) == prod(hi .- lo .+ 1) ||
+        throw(ArrayFormFallback("interior is not a contiguous box"))
+    ranges = Dict(j => lo[j]:hi[j] for j in 1:N)
+    array_validate_boundary_values(pde, s, derivweights)
+    c = SpectralArrayContext(s, derivweights, indexmap, args, slicevars, pde)
+    lhs = spectral_arrayify(pde.lhs, ranges, c)
+    rhs = spectral_arrayify(pde.rhs, ranges, c)
+    donor = array_slice(depvar(eqvar, s), s, ranges, indexmap)
+    if is_array_valued(lhs) && !is_array_valued(rhs)
+        rhs = array_broadcast_onto(rhs, donor)
+    elseif !is_array_valued(lhs) && is_array_valued(rhs)
+        lhs = array_broadcast_onto(lhs, donor)
+    elseif !is_array_valued(lhs) && !is_array_valued(rhs)
+        throw(ArrayFormFallback("equation contains no discretizable terms"))
+    end
+    return [lhs ~ rhs]
+end
+
+"""
+`array_boundary_derivative_expr` for a spectral operator: the boundary row of the
+differentiation matrix applied to the full slice along `x_`.
+"""
+function array_boundary_derivative_expr(
+        Dop::SpectralDerivativeOperator, II0, s, u, x_, j, N, ranges, indexmap, bcmap
+    )
+    innerranges = copy(ranges)
+    innerranges[j] = first(Dop.taps):last(Dop.taps)
+    row = Dop.rowmap[II0[j]]
+    return spectral_apply_along(
+        Dop.mat[row:row, :], j, array_slice(u, s, innerranges, indexmap)
+    )
+end
+
+"""
+Check that a derivative matching condition across a periodic seam holds identically
+under `FourierCollocation`, where both ends of the seam share a differentiation row.
+Evaluated at a single edge point: the row selection is the same across the face.
+"""
+function check_spectral_periodic_matching(s, boundaryvalfuncs, boundary, interiormap)
+    u = depvar(boundary.u, s)
+    args = ivs(u, s)
+    indexmap = Dict([args[i] => i for i in 1:length(args)])
+    E = edge(s, boundary, interiormap)
+    isempty(E) && return
+    II = first(E)
+    bc = boundary.eq
+    boundaryvalrules = mapreduce(f -> f(II), vcat, boundaryvalfuncs)
+    vmaps = varmaps(s, boundary.depvars, II, indexmap)
+    varrules = axiesvals(s, u, boundary.x, II)
+    rules = Dict(vcat(boundaryvalrules, vmaps, varrules))
+    lhs = pde_substitute(bc.lhs, rules)
+    rhs = pde_substitute(bc.rhs, rules)
+    isequal(lhs, rhs) || throw(
+        ArgumentError(
+            "Periodic boundary condition $(boundary.eq) is inconsistent with the `FourierCollocation` discretization: derivative matching is automatic for the trigonometric interpolant and cannot express a jump."
+        )
+    )
+    return
+end
+
 function PDEBase.discretize_equation!(
         disc_state::PDEBase.EquationState, pde::Equation, interiormap,
         eqvar, bcmap, depvars, s::DiscreteSpace,
@@ -151,43 +386,61 @@ function PDEBase.discretize_equation!(
     eqvarbcs = mapreduce(x -> bcmap[operation(eqvar)][x], vcat, s.x̄)
     for boundary in eqvarbcs
         if boundary isa HigherOrderInterfaceBoundary
-            # Periodic derivative matching is automatic for the trigonometric
-            # interpolant. Verify the condition is identically satisfied rather
-            # than emitting a redundant equation.
-            eqs = generate_bc_eqs(
-                s, boundaryvalfuncs, boundary, interiormap,
-                Dict(ivs(depvar(boundary.u, s), s) .=> eachindex(ivs(depvar(boundary.u, s), s)))
-            )
-            all(eq -> isequal(eq.lhs, eq.rhs), eqs) || throw(
-                ArgumentError(
-                    "Periodic boundary condition $(boundary.eq) is inconsistent with the `FourierCollocation` discretization: derivative matching is automatic for the trigonometric interpolant and cannot express a jump."
-                )
-            )
+            check_spectral_periodic_matching(s, boundaryvalfuncs, boundary, interiormap)
             continue
         end
-        generate_bc_eqs!(disc_state, s, boundaryvalfuncs, interiormap, boundary)
+        try
+            vcat!(
+                disc_state.bceqs,
+                array_bc_eqs(s, boundary, interiormap, derivweights, bcmap)
+            )
+        catch e
+            e isa InterruptException && rethrow(e)
+            reason = e isa ArrayFormFallback ? e.msg : sprint(showerror, e)
+            @debug "Array form falling back to pointwise boundary equations for $(boundary.eq): $reason"
+            generate_bc_eqs!(disc_state, s, boundaryvalfuncs, interiormap, boundary)
+        end
     end
-    generate_corner_eqs!(disc_state, s, interiormap, pde)
+    try
+        vcat!(
+            disc_state.bceqs,
+            array_corner_eqs(s, interiormap, eqvar, ndims(s.discvars[eqvar]))
+        )
+    catch e
+        e isa InterruptException && rethrow(e)
+        reason = e isa ArrayFormFallback ? e.msg : sprint(showerror, e)
+        @debug "Array form falling back to pointwise corner equations: $reason"
+        generate_corner_eqs!(
+            disc_state, s, interiormap, ndims(s.discvars[eqvar]), eqvar
+        )
+    end
 
     interior = interiormap.I[pde]
-    if isempty(interior)
-        push!(
-            disc_state.eqs,
+    eqs = if isempty(interior)
+        [
             discretize_equation_at_point(
                 CartesianIndex(), s, depvars, pde, derivweights,
                 bcmap, eqvar, indexmap, boundaryvalfuncs
-            )
-        )
+            ),
+        ]
     else
-        for II in interior
-            push!(
-                disc_state.eqs,
-                discretize_equation_at_point(
-                    II, s, depvars, pde, derivweights,
-                    bcmap, eqvar, indexmap, boundaryvalfuncs
-                )
+        try
+            discretize_spectral_array_form(
+                pde, interior, s, depvars, derivweights, eqvar, indexmap
+            )
+        catch e
+            e isa InterruptException && rethrow(e)
+            reason = e isa ArrayFormFallback ? e.msg : sprint(showerror, e)
+            @debug "Array form falling back to pointwise discretization for $pde: $reason"
+            vec(
+                map(interior) do II
+                    discretize_equation_at_point(
+                        II, s, depvars, pde, derivweights,
+                        bcmap, eqvar, indexmap, boundaryvalfuncs
+                    )
+                end
             )
         end
     end
-    return disc_state.eqs
+    return vcat!(disc_state.eqs, eqs)
 end

--- a/src/discretization/pseudospectral_discretize.jl
+++ b/src/discretization/pseudospectral_discretize.jl
@@ -284,8 +284,12 @@ function spectral_array_derivative(term, ranges, c::SpectralArrayContext)
         spectral_arrayify(inner, innerranges, c)
     end
     is_array_valued(val) || return 0
-    if D.fast !== nothing && rows == 1:size(D.mat, 1)
-        return spectral_apply_along(D.fast, j, val)
+    if D.fast !== nothing && rows == first(rows):last(rows)
+        full = spectral_apply_along(D.fast, j, val)
+        length(rows) == size(D.mat, 1) && return full
+        # differentiate on every node, then keep the rows asked for
+        rs = ntuple(k -> k == j ? (first(rows):last(rows)) : (1:size(full, k)), ndims(full))
+        return full[rs...]
     end
     return spectral_apply_along(D.mat[rows, :], j, val)
 end

--- a/src/discretization/schemes/pseudospectral/pseudospectral.jl
+++ b/src/discretization/schemes/pseudospectral/pseudospectral.jl
@@ -1,0 +1,277 @@
+# Pseudospectral discretization.
+#
+# A spectral differentiation matrix is used in place of the finite difference
+# stencils. Each row of the matrix is the full-width stencil for one grid
+# point, so the same `central_difference`/`sym_dot` machinery as the finite
+# difference path applies: the taps of an interior point are simply all the
+# collocation points of the direction.
+#
+# For a periodic (Fourier) direction the grid holds `N + 1` points for `N`
+# distinct equispaced collocation points - the first and last grid points are
+# the same physical node. `rowmap` folds the duplicated endpoint back to the
+# first distinct point and `taps` runs over the distinct points `2:n` only, so
+# the algebraic boundary unknown `u[1]` (pinned by `u[1] ~ u[end]`) is never
+# tapped and never counted twice.
+
+"""
+    SpectralDerivativeOperator
+
+Dense differentiation matrix acting along one independent variable. `mat[i, :]`
+is the differentiation row for matrix-index `i`; `rowmap[g]` maps grid index
+`g` to its matrix row; `taps` lists the grid indices the columns act on.
+"""
+struct SpectralDerivativeOperator{T <: Real, M <: AbstractMatrix{T}}
+    derivative_order::Int
+    mat::M
+    taps::Vector{Int}
+    rowmap::Vector{Int}
+end
+
+"""
+The `DifferentialDiscretizer` analogue for `PseudospectralDiscretization`: maps
+`Differential(x)^d` to the corresponding `SpectralDerivativeOperator`.
+"""
+struct SpectralDifferentialDiscretizer{D1} <: AbstractDifferentialDiscretizer
+    map::D1
+    orders::Any
+    icformulas::Any
+end
+
+"""
+    spectral_grid(spec, a, b)
+
+The collocation grid for `spec` on the domain `[a, b]`.
+"""
+function spectral_grid(spec::ChebyshevCollocation, a, b)
+    n = spec.n
+    return [a + (b - a) / 2 * (1 - cospi((k - 1) / (n - 1))) for k in 1:n]
+end
+
+function spectral_grid(spec::FourierCollocation, a, b)
+    return collect(range(a, b, spec.n + 1))
+end
+
+function spectral_grid(spec::AbstractVector, a, b)
+    issorted(spec) || throw(ArgumentError("Custom collocation grids must be sorted in ascending order."))
+    (spec[1] ≈ a && spec[end] ≈ b) ||
+        throw(ArgumentError("Custom collocation grid endpoints $(spec[1]), $(spec[end]) do not match the domain [$a, $b]."))
+    return collect(spec)
+end
+
+"""
+    spectral_diff_matrix(spec, grid, order)
+
+Differentiation matrix of order `order` for the collocation scheme `spec` on
+`grid`. Fourier directions use the explicit trigonometric-interpolant first
+derivative matrix (Trefethen, *Spectral Methods in MATLAB*) raised to `order`;
+everything else uses the maximal-stencil Fornberg weights, i.e. the
+polynomial-interpolant differentiation matrix.
+"""
+function spectral_diff_matrix(spec, grid, order)
+    n = length(grid)
+    order < n ||
+        throw(ArgumentError("Cannot take derivative order $order on $n collocation points."))
+    D = zeros(eltype(grid), n, n)
+    for i in 1:n
+        D[i, :] = calculate_weights(order, grid[i], grid)
+    end
+    return D
+end
+
+function spectral_diff_matrix(spec::FourierCollocation, grid, order)
+    N = spec.n
+    L = grid[end] - grid[1]
+    D = zeros(eltype(grid), N, N)
+    for i in 1:N, j in 1:N
+        i == j && continue
+        k = i - j
+        if iseven(N)
+            D[i, j] = (π / L) * (-1)^k * cot(π * k / N)
+        else
+            D[i, j] = (π / L) * (-1)^k * csc(π * k / N)
+        end
+    end
+    return D^order
+end
+
+"""
+    spectral_taps_rowmap(spec, n)
+
+The tapped grid indices and the grid-index-to-matrix-row map for `spec` on a
+grid of `n` points.
+"""
+spectral_taps_rowmap(spec, n) = collect(1:n), collect(1:n)
+function spectral_taps_rowmap(spec::FourierCollocation, n)
+    # Interior indices are 2:n; matrix index j pairs with grid index j + 1.
+    # Grid index 1 aliases grid index n, i.e. matrix index n - 1 = spec.n.
+    return collect(2:n), [mod(i - 2, spec.n) + 1 for i in 1:n]
+end
+
+function PDEBase.construct_differential_discretizer(
+        pdesys, s::DiscreteSpace, discretization::PseudospectralDiscretization, orders
+    )
+    differentialmap = Dict{Differential, SpectralDerivativeOperator}()
+    for x in s.x̄
+        spec = discretization.dxs[x]
+        grid = s.grid[x]
+        n = length(grid)
+        taps, rowmap = spectral_taps_rowmap(spec, n)
+        for d in union(orders[x], [1])
+            D = spectral_diff_matrix(spec, grid, d)
+            differentialmap[Differential(x)^d] = SpectralDerivativeOperator(
+                d, D, taps, rowmap
+            )
+        end
+    end
+    return SpectralDifferentialDiscretizer{typeof(differentialmap)}(
+        differentialmap, orders, array_ic_formulas(pdesys, s)
+    )
+end
+
+"""
+`central_difference_weights_and_stencil` for `SpectralDerivativeOperator`:
+the stencil of an interior point is the full matrix row over all collocation
+points of the direction.
+"""
+function central_difference_weights_and_stencil(
+        D::SpectralDerivativeOperator, II, s, bs, jx, u
+    )
+    j, x = jx
+    ndims(u, s) == 0 && return 0
+    I1 = unitindex(ndims(u, s), j)
+    weights = D.mat[D.rowmap[II[j]], :]
+    Itap = [II + (k - II[j]) * I1 for k in D.taps]
+    return weights, Itap
+end
+
+"""
+    spectral_eval(ex, II, s, derivweights, indexmap)
+
+Evaluate the expression `ex` at grid point `II` under spectral discretization.
+Spatial differentials become differentiation-matrix row dots; dependent
+variable calls become the matching discrete unknown (boundary literals resolve
+to the boundary index via `newindex`); independent variables become their grid
+value. This is the collocation analogue of the substitution rules used by the
+finite difference path, and transparently handles nested derivative terms such
+as `Dx(a(u) * Dx(u))` by evaluating the argument at every tap of the outer
+derivative row.
+"""
+function spectral_eval(ex, II, s, derivweights, indexmap)
+    ex = safe_unwrap(ex)
+    if !iscall(ex)
+        for (x, j) in indexmap
+            isequal(ex, safe_unwrap(x)) && return s.grid[x][II[j]]
+        end
+        return ex
+    end
+    op = operation(ex)
+    args = arguments(ex)
+    if op isa Differential
+        x = op.x
+        if s.time !== nothing && isequal(safe_unwrap(x), safe_unwrap(s.time))
+            return op(spectral_eval(args[1], II, s, derivweights, indexmap))
+        end
+        haskey(indexmap, x) || throw(
+            ArgumentError("Cannot take a spectral derivative with respect to $x, which is not an independent variable of the discretized equation.")
+        )
+        D = derivweights.map[Differential(x)^op.order]
+        return spectral_apply(D, args[1], II, s, derivweights, indexmap, x)
+    elseif op isa Integral
+        throw(ArgumentError("PseudospectralDiscretization does not yet support `Integral` terms, got $ex. Please post an issue if you need this feature."))
+    elseif any(o -> isequal(op, o), s.vars.depvar_ops)
+        u = depvar(ex, s)
+        return s.discvars[u][newindex(ex, II, s, indexmap)]
+    else
+        return op(Tuple(spectral_eval(a, II, s, derivweights, indexmap) for a in args)...)
+    end
+end
+
+"""
+    spectral_apply(D, inner, II, s, derivweights, indexmap, x)
+
+`Differential(x)^d(inner)` at `II` as a differentiation-matrix row dot. When
+`inner` is a dependent variable call the literal arguments pin the row (so
+`Dx(u(t, a))` is the derivative at the boundary), otherwise `inner` is
+recursively evaluated at every tap of the row.
+"""
+function spectral_apply(D, inner, II, s, derivweights, indexmap, x)
+    if iscall(inner) && any(o -> isequal(operation(inner), o), s.vars.depvar_ops)
+        u = depvar(inner, s)
+        p = x2i(s, u, x)
+        # `inner` does not depend on `x`: its derivative vanishes
+        p === nothing && return 0
+        base = Tuple(newindex(inner, II, s, indexmap))
+        row = D.mat[D.rowmap[base[p]], :]
+        vals = map(D.taps) do k
+            idx = CartesianIndex(base[1:(p - 1)]..., k, base[(p + 1):end]...)
+            s.discvars[u][idx]
+        end
+        return sym_dot(row, vals)
+    else
+        j = indexmap[x]
+        I1 = unitindex(length(II), j)
+        row = D.mat[D.rowmap[II[j]], :]
+        vals = map(D.taps) do k
+            spectral_eval(inner, II + (k - II[j]) * I1, s, derivweights, indexmap)
+        end
+        return sym_dot(row, vals)
+    end
+end
+
+"""
+`generate_finite_difference_rules` for `SpectralDifferentialDiscretizer`.
+
+Emits a substitution rule for every `Differential(x)^d)(u)` appearing, plus a
+rule for each term headed by a spatial derivative whose argument is not a
+plain dependent variable call (nested derivatives such as `Dx(u * Dx(u))`,
+mixed derivatives `Dx(Dy(u))`, and boundary-value derivatives like
+`Dx(u(t, 0))`).
+"""
+function generate_finite_difference_rules(
+        II::CartesianIndex, s::DiscreteSpace, depvars, pde::Equation,
+        derivweights::SpectralDifferentialDiscretizer, bmap, indexmap
+    )
+    length(II) == 0 && return []
+    terms = split_terms(pde, s.x̄)
+    rules = Pair[]
+    stencilvars = idx_depvars(depvars, s, indexmap)
+    for u in stencilvars
+        for x in ivs(u, s)
+            for d in derivweights.orders[x]
+                term = (Differential(x)^d)(u)
+                push!(
+                    rules,
+                    term => spectral_eval(term, II, s, derivweights, indexmap)
+                )
+            end
+        end
+    end
+    # Rules for spatial-derivative-headed subterms not covered by the depvar
+    # rules above: nested derivatives (`Dx(u * Dx(u))`, `Dx(u^2)`), mixed
+    # derivatives, and derivatives of literal boundary values. Diff-headed
+    # subterms are evaluated by `spectral_eval`, which handles any deeper
+    # nesting itself, so there is no need to descend below them.
+    diff_terms = Any[]
+    for t in terms
+        find_diff_terms!(diff_terms, t, s.x̄)
+    end
+    for t in unique!(diff_terms)
+        push!(rules, t => spectral_eval(t, II, s, derivweights, indexmap))
+    end
+    return rules
+end
+
+function find_diff_terms!(out, t, x̄)
+    iscall(t) || return
+    op = operation(t)
+    if op isa Differential && any(x -> isequal(op.x, x), x̄)
+        push!(out, t)
+        return
+    elseif op isa Integral
+        throw(ArgumentError("PseudospectralDiscretization does not yet support `Integral` terms, got $t. Please post an issue if you need this feature."))
+    end
+    for a in arguments(t)
+        find_diff_terms!(out, a, x̄)
+    end
+    return
+end

--- a/src/discretization/schemes/pseudospectral/pseudospectral.jl
+++ b/src/discretization/schemes/pseudospectral/pseudospectral.jl
@@ -1,10 +1,12 @@
-# Pseudospectral discretization.
+# Pseudospectral discretization: grids, differentiation matrices and the pointwise
+# collocation rules.
 #
 # A spectral differentiation matrix is used in place of the finite difference
 # stencils. Each row of the matrix is the full-width stencil for one grid
 # point, so the same `central_difference`/`sym_dot` machinery as the finite
 # difference path applies: the taps of an interior point are simply all the
-# collocation points of the direction.
+# collocation points of the direction. The pointwise rules here are the fallback
+# for the slice form in `discretization/pseudospectral_discretize.jl`.
 #
 # For a periodic (Fourier) direction the grid holds `N + 1` points for `N`
 # distinct equispaced collocation points - the first and last grid points are

--- a/src/discretization/schemes/pseudospectral/pseudospectral.jl
+++ b/src/discretization/schemes/pseudospectral/pseudospectral.jl
@@ -20,13 +20,53 @@
 
 Dense differentiation matrix acting along one independent variable. `mat[i, :]`
 is the differentiation row for matrix-index `i`; `rowmap[g]` maps grid index
-`g` to its matrix row; `taps` lists the grid indices the columns act on.
+`g` to its matrix row; `taps` lists the grid indices the columns act on. `fast`
+is an operator equivalent to `mat` over the whole direction that the array form
+prefers when every row is needed (an FFT operator for Fourier directions, see
+[`fast_fourier_operator`](@ref)), or `nothing`.
 """
-struct SpectralDerivativeOperator{T <: Real, M <: AbstractMatrix{T}}
+struct SpectralDerivativeOperator{T <: Real, M <: AbstractMatrix{T}, F}
     derivative_order::Int
     mat::M
     taps::Vector{Int}
     rowmap::Vector{Int}
+    fast::F
+end
+
+"""
+    fast_fourier_operator(spec::FourierCollocation, grid, d, mat)
+
+An operator applying the order-`d` Fourier derivative over the whole direction
+with FFTs, equivalent to the dense matrix `mat`, or `nothing` when no FFT backend
+is available. Defined by the `AbstractFFTs` extension; the default is `nothing`.
+"""
+fast_fourier_operator(spec, grid, d, mat) = nothing
+
+"""
+    apply_along(op, X, ::Val{J})
+
+Apply the whole-direction derivative operator `op` along axis `J` of `X`. For a
+matrix `op` this is `op * X` contracted over axis `J`; the `AbstractFFTs`
+extension adds FFT operators.
+"""
+function apply_along(mat::AbstractMatrix, X::AbstractVector, ::Val{1})
+    return mat * X
+end
+
+function apply_along(mat::AbstractMatrix, X::AbstractArray{T, N}, ::Val{J}) where {T, N, J}
+    sz = size(X)
+    m = size(mat, 1)
+    J == 1 && return reshape(mat * reshape(X, sz[1], :), m, sz[2:end]...)
+    J == N && return reshape(reshape(X, :, sz[N]) * transpose(mat), sz[1:(N - 1)]..., m)
+    nb = prod(sz[1:(J - 1)])
+    na = prod(sz[(J + 1):end])
+    Xr = reshape(X, nb, sz[J], na)
+    Y = similar(X, promote_type(eltype(mat), T), (sz[1:(J - 1)]..., m, sz[(J + 1):end]...))
+    Yr = reshape(Y, nb, m, na)
+    for a in 1:na
+        LinearAlgebra.mul!(view(Yr, :, :, a), view(Xr, :, :, a), transpose(mat))
+    end
+    return Y
 end
 
 """
@@ -120,8 +160,10 @@ function PDEBase.construct_differential_discretizer(
         taps, rowmap = spectral_taps_rowmap(spec, n)
         for d in union(orders[x], [1])
             D = spectral_diff_matrix(spec, grid, d)
+            fast = spec isa FourierCollocation && spec.fft ?
+                fast_fourier_operator(spec, grid, d, D) : nothing
             differentialmap[Differential(x)^d] = SpectralDerivativeOperator(
-                d, D, taps, rowmap
+                d, D, taps, rowmap, fast
             )
         end
     end

--- a/src/discretization/schemes/pseudospectral/pseudospectral.jl
+++ b/src/discretization/schemes/pseudospectral/pseudospectral.jl
@@ -22,8 +22,7 @@ Dense differentiation matrix acting along one independent variable. `mat[i, :]`
 is the differentiation row for matrix-index `i`; `rowmap[g]` maps grid index
 `g` to its matrix row; `taps` lists the grid indices the columns act on. `fast`
 is an operator equivalent to `mat` over the whole direction that the array form
-prefers when every row is needed (an FFT operator for Fourier directions, see
-[`fast_fourier_operator`](@ref)), or `nothing`.
+prefers (an FFT operator, see [`fast_spectral_operator`](@ref)), or `nothing`.
 """
 struct SpectralDerivativeOperator{T <: Real, M <: AbstractMatrix{T}, F}
     derivative_order::Int
@@ -34,13 +33,14 @@ struct SpectralDerivativeOperator{T <: Real, M <: AbstractMatrix{T}, F}
 end
 
 """
-    fast_fourier_operator(spec::FourierCollocation, grid, d, mat)
+    fast_spectral_operator(spec, grid, d, mat)
 
-An operator applying the order-`d` Fourier derivative over the whole direction
-with FFTs, equivalent to the dense matrix `mat`, or `nothing` when no FFT backend
-is available. Defined by the `AbstractFFTs` extension; the default is `nothing`.
+An operator applying the order-`d` derivative over the whole direction with FFTs,
+equivalent to the dense matrix `mat`, or `nothing` when no FFT backend is
+available. Defined by the `AbstractFFTs` extension for `FourierCollocation` and
+`ChebyshevCollocation`; the default is `nothing`.
 """
-fast_fourier_operator(spec, grid, d, mat) = nothing
+fast_spectral_operator(spec, grid, d, mat) = nothing
 
 """
     apply_along(op, X, ::Val{J})
@@ -105,9 +105,12 @@ end
 
 Differentiation matrix of order `order` for the collocation scheme `spec` on
 `grid`. Fourier directions use the explicit trigonometric-interpolant first
-derivative matrix (Trefethen, *Spectral Methods in MATLAB*) raised to `order`;
-everything else uses the maximal-stencil Fornberg weights, i.e. the
-polynomial-interpolant differentiation matrix.
+derivative matrix (Trefethen, *Spectral Methods in MATLAB*) raised to `order`.
+Chebyshev–Lobatto directions use the Weideman–Reddy `chebdif` recursion, which
+builds every order directly with the negative-sum trick and stays finite for
+thousands of nodes. Custom grids use the maximal-stencil Fornberg weights, i.e.
+the polynomial-interpolant differentiation matrix, which overflow beyond roughly a
+thousand nodes.
 """
 function spectral_diff_matrix(spec, grid, order)
     n = length(grid)
@@ -118,6 +121,38 @@ function spectral_diff_matrix(spec, grid, order)
         D[i, :] = calculate_weights(order, grid[i], grid)
     end
     return D
+end
+
+function spectral_diff_matrix(spec::ChebyshevCollocation, grid, order)
+    n = spec.n
+    order < n ||
+        throw(ArgumentError("Cannot take derivative order $order on $n collocation points."))
+    T = float(eltype(grid))
+    # Weideman & Reddy, "A MATLAB differentiation matrix suite" (2000), `chebdif`, on the
+    # descending nodes cos(πk/(n-1)); the grid here is the affine image with the same index
+    # order, x = a + (b - a)/2 (1 - cos(πk/(n-1))), so the result scales by (-2/(b - a))^order.
+    N = n - 1
+    k = 0:N
+    th = k .* (T(π) / N)
+    n1 = N ÷ 2
+    n2 = (N + 1) ÷ 2   # ceil(n/2) rows, flipped, complete the differences without cancellation
+    Tm = repeat(th ./ 2, 1, n)
+    DX = 2 .* sin.(permutedims(Tm) .+ Tm) .* sin.(permutedims(Tm) .- Tm)
+    DX = vcat(DX[1:(n1 + 1), :], -reverse(reverse(DX[1:n2, :]; dims = 1); dims = 2))
+    DX[diagind(DX)] .= one(T)
+    C = T[(-1)^(i + j) for i in k, j in k]
+    C[1, :] .*= 2
+    C[end, :] .*= 2
+    C[:, 1] ./= 2
+    C[:, end] ./= 2
+    Z = 1 ./ DX
+    Z[diagind(Z)] .= zero(T)
+    D = Matrix{T}(I, n, n)
+    for ell in 1:order
+        D = ell .* Z .* (C .* repeat(diag(D), 1, n) .- D)
+        D[diagind(D)] .= .-vec(sum(D; dims = 2))
+    end
+    return D .* (-2 / T(grid[end] - grid[1]))^order
 end
 
 function spectral_diff_matrix(spec::FourierCollocation, grid, order)
@@ -160,8 +195,8 @@ function PDEBase.construct_differential_discretizer(
         taps, rowmap = spectral_taps_rowmap(spec, n)
         for d in union(orders[x], [1])
             D = spectral_diff_matrix(spec, grid, d)
-            fast = spec isa FourierCollocation && spec.fft ?
-                fast_fourier_operator(spec, grid, d, D) : nothing
+            fast = spec isa AbstractSpectralScheme && spec.fft ?
+                fast_spectral_operator(spec, grid, d, D) : nothing
             differentialmap[Differential(x)^d] = SpectralDerivativeOperator(
                 d, D, taps, rowmap, fast
             )

--- a/src/interface/PseudospectralDiscretization.jl
+++ b/src/interface/PseudospectralDiscretization.jl
@@ -1,0 +1,126 @@
+abstract type AbstractSpectralScheme end
+
+"""
+    ChebyshevCollocation(n)
+
+Chebyshev–Lobatto pseudospectral collocation with `n` grid points on the domain
+`[a, b]`, including both endpoints. Spatial derivatives of order `d` are
+discretized with the differentiation matrix of the degree `n - 1` polynomial
+interpolant through the grid values (equivalently, the maximal-stencil Fornberg
+weights on the Lobatto nodes).
+
+Use this scheme for directions with non-periodic (truncating) boundary
+conditions such as Dirichlet or Neumann conditions.
+"""
+struct ChebyshevCollocation <: AbstractSpectralScheme
+    n::Int
+    function ChebyshevCollocation(n)
+        n >= 2 || throw(ArgumentError("ChebyshevCollocation requires at least 2 collocation points, got $n"))
+        return new(n)
+    end
+end
+
+"""
+    FourierCollocation(n)
+
+Fourier pseudospectral collocation with `n` distinct equispaced grid points on
+the periodic domain `[a, b)`. The grid stores `n + 1` points, with the upper
+endpoint identified with the lower endpoint by the periodic boundary
+condition `u(t, a) ~ u(t, b)`.
+
+Spatial derivatives of order `d` are discretized with the differentiation
+matrix of the trigonometric interpolant, computed as the `d`th power of the
+first-derivative matrix.
+
+This scheme requires a periodic boundary condition in the associated
+direction; conversely, periodic directions must use `FourierCollocation`.
+"""
+struct FourierCollocation <: AbstractSpectralScheme
+    n::Int
+    function FourierCollocation(n)
+        n >= 4 || throw(ArgumentError("FourierCollocation requires at least 4 collocation points, got $n"))
+        return new(n)
+    end
+end
+
+"""
+    PseudospectralDiscretization(dxs, time = nothing; kwargs...)
+
+A pseudospectral (collocation) discretization algorithm.
+
+Each spatial independent variable is discretized on a collocation grid, and
+every spatial derivative `Differential(x)^d` is replaced by the dense
+differentiation matrix of the spectral interpolant in that direction. Boundary
+conditions are enforced by replacing the equation at the boundary points with
+the boundary equation, exactly as in [`MOLFiniteDifference`](@ref). Nested
+derivative terms such as `Differential(x)(a(u) * Differential(x)(u))` are
+evaluated directly by collocation, so no PDE-system transformation is needed.
+
+# Arguments
+
+- `dxs`: A vector of pairs mapping each independent variable to a collocation
+  specification:
+  - `x => n::Integer` or `x => ChebyshevCollocation(n)` discretizes `x` on `n`
+    Chebyshev–Lobatto points. Use for non-periodic directions.
+  - `x => FourierCollocation(n)` discretizes `x` on `n` distinct equispaced
+    points and requires a periodic boundary condition `u(t, a) ~ u(t, b)` in
+    that direction. Higher-order periodic matching conditions such as
+    `Differential(x)(u(t, a)) ~ Differential(x)(u(t, b))` are redundant - they
+    are satisfied identically by the trigonometric interpolant - and are
+    skipped.
+  - `x => grid::AbstractVector` uses a custom set of `n` collocation nodes
+    (polynomial-interpolation derivatives via Fornberg weights).
+- `time`: The continuous variable, usually time. If `time = nothing`,
+  discretization yields a `NonlinearProblem`. Defaults to `nothing`.
+
+# Keywords
+
+- `kwargs`: Additional keyword arguments passed to the generated problem.
+
+# Example
+
+```julia
+using ModelingToolkit, MethodOfLines
+
+@parameters t x
+@variables u(..)
+Dt = Differential(t)
+Dxx = Differential(x)^2
+
+# Chebyshev collocation on 32 points
+discretization = PseudospectralDiscretization([x => 32], t)
+
+# Fourier collocation on 64 distinct points, for a periodic domain
+discretization = PseudospectralDiscretization([x => FourierCollocation(64)], t)
+```
+
+# Limitations
+
+- Multi-domain (interface) boundary conditions are not supported; only
+  same-variable periodic conditions may be used with `FourierCollocation`.
+- `Integral` terms are not supported.
+- Unlike `MOLFiniteDifference`, there is no upwinding or special scheme
+  selection: all derivative orders in a direction share the same spectral
+  differentiation matrix.
+"""
+struct PseudospectralDiscretization <: AbstractEquationSystemDiscretization
+    dxs::Any
+    time::Any
+    kwargs::Any
+end
+
+function PseudospectralDiscretization(dxs, time = nothing; kwargs...)
+    @assert (time isa Num) | (time isa Nothing) "time must be a Num, or Nothing - got $(typeof(time)). See docs for PseudospectralDiscretization."
+
+    dxs = Dict{Any, Any}(dxs)
+    for (x, spec) in dxs
+        spec isa Integer && (dxs[x] = ChebyshevCollocation(spec))
+        dxs[x] isa Union{AbstractSpectralScheme, AbstractVector} ||
+            throw(ArgumentError("Invalid collocation specification $(dxs[x]) for $x. Pass an Integer, ChebyshevCollocation(n), FourierCollocation(n), or a grid vector."))
+    end
+    return PseudospectralDiscretization(dxs, time, kwargs)
+end
+
+PDEBase.get_time(disc::PseudospectralDiscretization) = disc.time
+
+const MOLDiscretization = Union{MOLFiniteDifference, PseudospectralDiscretization}

--- a/src/interface/PseudospectralDiscretization.jl
+++ b/src/interface/PseudospectralDiscretization.jl
@@ -50,11 +50,20 @@ A pseudospectral (collocation) discretization algorithm.
 
 Each spatial independent variable is discretized on a collocation grid, and
 every spatial derivative `Differential(x)^d` is replaced by the dense
-differentiation matrix of the spectral interpolant in that direction. Boundary
-conditions are enforced by replacing the equation at the boundary points with
-the boundary equation, exactly as in [`MOLFiniteDifference`](@ref). Nested
-derivative terms such as `Differential(x)(a(u) * Differential(x)(u))` are
-evaluated directly by collocation, so no PDE-system transformation is needed.
+differentiation matrix of the spectral interpolant in that direction, applied in
+physical (grid) space; no transform to spectral coefficients is taken. Boundary
+conditions replace the equation at the boundary nodes, exactly as in
+[`MOLFiniteDifference`](@ref), with derivatives in a condition taken from the
+boundary row of the differentiation matrix. Nested derivative terms such as
+`Differential(x)(a(u) * Differential(x)(u))` are evaluated directly by
+collocation, so no PDE-system transformation is needed.
+
+The interior of each PDE is emitted as one symbolic array equation over slices of
+the discretized variables, with each derivative an opaque operator holding its
+differentiation matrix, so the number of symbolic equations and the size of the
+generated code are independent of the resolution in one and two spatial
+dimensions. See the [pseudospectral](@ref pseudospectral) documentation page for
+the boundary conditions each grid type accepts and the scaling.
 
 # Arguments
 
@@ -102,6 +111,8 @@ discretization = PseudospectralDiscretization([x => FourierCollocation(64)], t)
 - Unlike `MOLFiniteDifference`, there is no upwinding or special scheme
   selection: all derivative orders in a direction share the same spectral
   differentiation matrix.
+- Derivatives are dense matrix products, `O(n^2)` per application in one
+  dimension, and the Jacobian is dense.
 """
 struct PseudospectralDiscretization <: AbstractEquationSystemDiscretization
     dxs::Any

--- a/src/interface/PseudospectralDiscretization.jl
+++ b/src/interface/PseudospectralDiscretization.jl
@@ -21,7 +21,7 @@ struct ChebyshevCollocation <: AbstractSpectralScheme
 end
 
 """
-    FourierCollocation(n)
+    FourierCollocation(n; fft = true)
 
 Fourier pseudospectral collocation with `n` distinct equispaced grid points on
 the periodic domain `[a, b)`. The grid stores `n + 1` points, with the upper
@@ -30,16 +30,21 @@ condition `u(t, a) ~ u(t, b)`.
 
 Spatial derivatives of order `d` are discretized with the differentiation
 matrix of the trigonometric interpolant, computed as the `d`th power of the
-first-derivative matrix.
+first-derivative matrix. When an `AbstractFFTs` backend such as `FFTW` is loaded
+and `fft = true`, whole-direction derivatives in the array form are applied with
+real FFTs instead of the dense matrix, `O(n log n)` per application rather than
+`O(n^2)`; the two agree to roundoff. Pass `fft = false` to always use the dense
+matrix.
 
 This scheme requires a periodic boundary condition in the associated
 direction; conversely, periodic directions must use `FourierCollocation`.
 """
 struct FourierCollocation <: AbstractSpectralScheme
     n::Int
-    function FourierCollocation(n)
+    fft::Bool
+    function FourierCollocation(n; fft = true)
         n >= 4 || throw(ArgumentError("FourierCollocation requires at least 4 collocation points, got $n"))
-        return new(n)
+        return new(n, fft)
     end
 end
 
@@ -61,9 +66,10 @@ collocation, so no PDE-system transformation is needed.
 The interior of each PDE is emitted as one symbolic array equation over slices of
 the discretized variables, with each derivative an opaque operator holding its
 differentiation matrix, so the number of symbolic equations and the size of the
-generated code are independent of the resolution in one and two spatial
-dimensions. See the [pseudospectral](@ref pseudospectral) documentation page for
-the boundary conditions each grid type accepts and the scaling.
+generated code are independent of the resolution. Fourier directions use FFTs for
+the derivative when an `AbstractFFTs` backend such as `FFTW` is loaded. See the
+[pseudospectral](@ref pseudospectral) documentation page for the boundary
+conditions each grid type accepts and the scaling.
 
 # Arguments
 

--- a/src/interface/PseudospectralDiscretization.jl
+++ b/src/interface/PseudospectralDiscretization.jl
@@ -1,22 +1,28 @@
 abstract type AbstractSpectralScheme end
 
 """
-    ChebyshevCollocation(n)
+    ChebyshevCollocation(n; fft = true)
 
 Chebyshev–Lobatto pseudospectral collocation with `n` grid points on the domain
 `[a, b]`, including both endpoints. Spatial derivatives of order `d` are
 discretized with the differentiation matrix of the degree `n - 1` polynomial
 interpolant through the grid values (equivalently, the maximal-stencil Fornberg
-weights on the Lobatto nodes).
+weights on the Lobatto nodes). When an `AbstractFFTs` backend such as `FFTW` is
+loaded and `fft = true`, whole-direction derivatives in the array form are
+computed through the Chebyshev transform (a DCT-I via the FFT of the even
+extension) and the coefficient recurrence instead of the dense matrix, at
+`O(n log n)` per application; the two agree to roundoff. Pass `fft = false` to
+always use the dense matrix.
 
 Use this scheme for directions with non-periodic (truncating) boundary
 conditions such as Dirichlet or Neumann conditions.
 """
 struct ChebyshevCollocation <: AbstractSpectralScheme
     n::Int
-    function ChebyshevCollocation(n)
+    fft::Bool
+    function ChebyshevCollocation(n; fft = true)
         n >= 2 || throw(ArgumentError("ChebyshevCollocation requires at least 2 collocation points, got $n"))
-        return new(n)
+        return new(n, fft)
     end
 end
 
@@ -66,8 +72,9 @@ collocation, so no PDE-system transformation is needed.
 The interior of each PDE is emitted as one symbolic array equation over slices of
 the discretized variables, with each derivative an opaque operator holding its
 differentiation matrix, so the number of symbolic equations and the size of the
-generated code are independent of the resolution. Fourier directions use FFTs for
-the derivative when an `AbstractFFTs` backend such as `FFTW` is loaded. See the
+generated code are independent of the resolution. Derivatives are applied with
+FFTs in both Fourier and Chebyshev directions when an `AbstractFFTs` backend such
+as `FFTW` is loaded. See the
 [pseudospectral](@ref pseudospectral) documentation page for the boundary
 conditions each grid type accepts and the scaling.
 

--- a/src/interface/solution/MOLMetadata.jl
+++ b/src/interface/solution/MOLMetadata.jl
@@ -39,7 +39,7 @@ struct MOLMetadata{hasTime, Ds, Disc, PDE, M, C} <:
 end
 
 function PDEBase.generate_metadata(
-        s::DiscreteSpace, disc::MOLFiniteDifference, pdesys::PDESystem,
+        s::DiscreteSpace, disc::MOLDiscretization, pdesys::PDESystem,
         boundarymap, complexmap, u0 = []
     )
     return MOLMetadata(s, disc, pdesys, boundarymap, complexmap, nothing, u0)

--- a/src/system_parsing/interior_map.jl
+++ b/src/system_parsing/interior_map.jl
@@ -52,7 +52,7 @@ end
 
 function PDEBase.construct_var_equation_mapping(
         pdes::Vector{Equation}, boundarymap, s::DiscreteSpace{N, M},
-        discretization::MOLFiniteDifference
+        discretization::MOLDiscretization
     ) where {N, M}
     @assert length(pdes) == M "There must be the same number of equations and unknowns, got $(length(pdes)) equations and $(M) unknowns"
     validate_interface_orders(pdes, boundarymap, discretization)
@@ -73,7 +73,7 @@ function PDEBase.construct_var_equation_mapping(
         # Determine thec number of points to remove from each end of the domain for each dimension
         for b in boundaries
             #@show b
-            clip_interior!!(lower, upper, s, b)
+            clip_interior!!(lower, upper, s, b, discretization)
         end
         push!(vlower, pde => lower)
         push!(vupper, pde => upper)
@@ -102,7 +102,7 @@ function PDEBase.construct_var_equation_mapping(
     )
 end
 
-function generate_interior(lower, upper, u, s, disc::MOLFiniteDifference)
+function generate_interior(lower, upper, u, s, disc::MOLDiscretization)
     args = remove(arguments(u), s.time)
 
     ret = s.Igrid[u][

--- a/src/system_parsing/pde_system_transformation.jl
+++ b/src/system_parsing/pde_system_transformation.jl
@@ -5,7 +5,7 @@ Modified copilot explanation:
 
 """
 function PDEBase.transform_pde_system!(
-        v::PDEBase.VariableMap, boundarymap, sys::PDESystem, disc::MOLFiniteDifference
+        v::PDEBase.VariableMap, boundarymap, sys::PDESystem, disc::MOLDiscretization
     )
     eqs = copy(get_eqs(sys))
     bcs = copy(get_bcs(sys))

--- a/test/Pseudospectral/fft.jl
+++ b/test/Pseudospectral/fft.jl
@@ -1,0 +1,104 @@
+# FFT-based Fourier derivatives through the AbstractFFTs extension (FFTW backend),
+# and the array form in three spatial dimensions.
+
+using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using FFTW
+using SciMLBase: successful_retcode
+using ModelingToolkit: get_eqs
+
+const MOL = MethodOfLines
+
+@testset "FFT operator matches the dense matrix" begin
+    for N in (16, 15), d in 1:4
+        spec = FourierCollocation(N)
+        grid = MOL.spectral_grid(spec, -3.0, 5.0)
+        D = MOL.spectral_diff_matrix(spec, grid, d)
+        op = MOL.fast_fourier_operator(spec, grid, d, D)
+        @test op !== nothing
+        v = randn(N)
+        @test MOL.apply_along(op, v, Val(1)) ≈ D * v atol = 1.0e-10
+        X = randn(N, 5)
+        @test MOL.apply_along(op, X, Val(1)) ≈ D * X atol = 1.0e-10
+        Y = randn(5, N)
+        @test MOL.apply_along(op, Y, Val(2)) ≈ Y * transpose(D) atol = 1.0e-10
+        Z = randn(3, N, 4)
+        ref = MOL.apply_along(D, Z, Val(2))
+        @test MOL.apply_along(op, Z, Val(2)) ≈ ref atol = 1.0e-10
+        for k in 1:4
+            @test ref[:, :, k] ≈ Z[:, :, k] * transpose(D)
+        end
+        # element types without a plan (dual numbers) go through the matrix
+        @test MOL.apply_along(op, big.(v), Val(1)) ≈ D * v atol = 1.0e-10
+    end
+end
+
+@testset "Kuramoto-Sivashinsky with FFT derivatives" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    L = 16.0
+    eq = Dt(u(t, x)) ~ -u(t, x) * Dx(u(t, x)) - (Dx^2)(u(t, x)) / 2 -
+        (Dx^4)(u(t, x)) / 16
+    bcs = [u(0, x) ~ cospi(2x / L), u(t, -L) ~ u(t, L)]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-L, L)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+
+    N = 64
+    dense = discretize(pdesys, PseudospectralDiscretization([x => FourierCollocation(N; fft = false)], t))
+    fast = discretize(pdesys, PseudospectralDiscretization([x => FourierCollocation(N)], t))
+    du = zeros(N + 1)
+    rd = similar(du)
+    rf = similar(du)
+    dense.f(rd, du, dense.u0, dense.p, 0.0)
+    fast.f(rf, du, fast.u0, fast.p, 0.0)
+    @test norm(rd - rf, Inf) < 1.0e-9
+    sys, _ = symbolic_discretize(pdesys, PseudospectralDiscretization([x => FourierCollocation(N)], t))
+    @test occursin("FourierFFTDerivative", string(get_eqs(sys)[1]))
+
+    sol_dense = solve(dense; abstol = 1.0e-8, reltol = 1.0e-8, saveat = 0.1)
+    sol_fft = solve(fast; abstol = 1.0e-8, reltol = 1.0e-8, saveat = 0.1)
+    @test successful_retcode(sol_dense) && successful_retcode(sol_fft)
+    @test norm(sol_dense[u(t, x)] - sol_fft[u(t, x)], Inf) < 1.0e-5
+end
+
+@testset "Three spatial dimensions" begin
+    # u = e^{-(pi^2/2 + 1) t} cos(pi x/2) cos(pi y/2) cos(z)
+    @parameters t x y z
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+    Dyy = Differential(y)^2
+    Dzz = Differential(z)^2
+    Lp = Float64(π)
+    eq = Dt(u(t, x, y, z)) ~ Dxx(u(t, x, y, z)) + Dyy(u(t, x, y, z)) + Dzz(u(t, x, y, z))
+    bcs = [
+        u(0, x, y, z) ~ cospi(x / 2) * cospi(y / 2) * cos(z),
+        u(t, -1, y, z) ~ 0.0, u(t, 1, y, z) ~ 0.0,
+        u(t, x, -1, z) ~ 0.0, u(t, x, 1, z) ~ 0.0,
+        u(t, x, y, -Lp) ~ u(t, x, y, Lp),
+    ]
+    domains = [
+        t ∈ Interval(0.0, 0.1), x ∈ Interval(-1.0, 1.0), y ∈ Interval(-1.0, 1.0),
+        z ∈ Interval(-Lp, Lp),
+    ]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x, y, z], [u(t, x, y, z)])
+    neqs = map(((8, 8), (12, 10))) do (n, m)
+        disc = PseudospectralDiscretization([x => n, y => n, z => FourierCollocation(m)], t)
+        sys, _ = symbolic_discretize(pdesys, disc)
+        @test length(ModelingToolkit.get_unknowns(sys)) == n * n * (m + 1)
+        length(get_eqs(sys))
+    end
+    # the equation count does not grow with the resolution
+    @test neqs[1] == neqs[2] < 40
+    disc = PseudospectralDiscretization([x => 10, y => 10, z => FourierCollocation(8)], t)
+    sol = solve(discretize(pdesys, disc); abstol = 1.0e-9, reltol = 1.0e-9)
+    @test successful_retcode(sol)
+    usol = sol[u(t, x, y, z)]
+    exact = [
+        exp(-(π^2 / 2 + 1) * ti) * cospi(xi / 2) * cospi(yi / 2) * cos(zi)
+            for ti in sol.t, xi in sol[x], yi in sol[y], zi in sol[z]
+    ]
+    # alias index of the periodic direction excluded, as in the 2D test
+    @test norm(usol[:, :, :, 2:end] - exact[:, :, :, 2:end], Inf) < 1.0e-6
+end

--- a/test/Pseudospectral/fft.jl
+++ b/test/Pseudospectral/fft.jl
@@ -8,28 +8,59 @@ using ModelingToolkit: get_eqs
 
 const MOL = MethodOfLines
 
-@testset "FFT operator matches the dense matrix" begin
-    for N in (16, 15), d in 1:4
-        spec = FourierCollocation(N)
+@testset "FFT operators match the dense matrices" begin
+    for spec in (
+                FourierCollocation(16), FourierCollocation(15), ChebyshevCollocation(17),
+                ChebyshevCollocation(16),
+            ), d in 1:4
+        N = spec.n
         grid = MOL.spectral_grid(spec, -3.0, 5.0)
         D = MOL.spectral_diff_matrix(spec, grid, d)
-        op = MOL.fast_fourier_operator(spec, grid, d, D)
+        op = MOL.fast_spectral_operator(spec, grid, d, D)
         @test op !== nothing
+        tol = 1.0e-9 * norm(D, Inf)
         v = randn(N)
-        @test MOL.apply_along(op, v, Val(1)) ≈ D * v atol = 1.0e-10
+        @test norm(MOL.apply_along(op, v, Val(1)) - D * v, Inf) < tol
         X = randn(N, 5)
-        @test MOL.apply_along(op, X, Val(1)) ≈ D * X atol = 1.0e-10
+        @test norm(MOL.apply_along(op, X, Val(1)) - D * X, Inf) < tol
         Y = randn(5, N)
-        @test MOL.apply_along(op, Y, Val(2)) ≈ Y * transpose(D) atol = 1.0e-10
+        @test norm(MOL.apply_along(op, Y, Val(2)) - Y * transpose(D), Inf) < tol
         Z = randn(3, N, 4)
         ref = MOL.apply_along(D, Z, Val(2))
-        @test MOL.apply_along(op, Z, Val(2)) ≈ ref atol = 1.0e-10
+        @test norm(MOL.apply_along(op, Z, Val(2)) - ref, Inf) < tol
         for k in 1:4
             @test ref[:, :, k] ≈ Z[:, :, k] * transpose(D)
         end
         # element types without a plan (dual numbers) go through the matrix
-        @test MOL.apply_along(op, big.(v), Val(1)) ≈ D * v atol = 1.0e-10
+        @test norm(MOL.apply_along(op, big.(v), Val(1)) - D * v, Inf) < tol
     end
+    # exact for a polynomial of the interpolant's degree
+    spec = ChebyshevCollocation(12)
+    grid = MOL.spectral_grid(spec, -1.0, 1.0)
+    D = MOL.spectral_diff_matrix(spec, grid, 2)
+    op = MOL.fast_spectral_operator(spec, grid, 2, D)
+    @test MOL.apply_along(op, grid .^ 11, Val(1)) ≈ 110 .* grid .^ 9 atol = 1.0e-9
+end
+
+@testset "Chebyshev heat equation with FFT derivatives" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+    bcs = [u(0, x) ~ cospi(x / 2), u(t, -1) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-1.0, 1.0)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    n = 20
+    sys, _ = symbolic_discretize(pdesys, PseudospectralDiscretization([x => n], t))
+    @test occursin("ChebyshevFFTDerivative", string(get_eqs(sys)[1]))
+    sys_dense, _ = symbolic_discretize(pdesys, PseudospectralDiscretization([x => ChebyshevCollocation(n; fft = false)], t))
+    @test !occursin("ChebyshevFFTDerivative", string(get_eqs(sys_dense)[1]))
+    prob = discretize(pdesys, PseudospectralDiscretization([x => n], t))
+    sol = solve(prob; abstol = 1.0e-10, reltol = 1.0e-10)
+    @test successful_retcode(sol)
+    exact = [exp(-π^2 * ti / 4) * cospi(xi / 2) for ti in sol.t, xi in sol[x]]
+    @test norm(sol[u(t, x)] - exact, Inf) < 1.0e-6
 end
 
 @testset "Kuramoto-Sivashinsky with FFT derivatives" begin

--- a/test/Pseudospectral/pseudospectral.jl
+++ b/test/Pseudospectral/pseudospectral.jl
@@ -1,0 +1,302 @@
+# Pseudospectral discretization tests, modeled on the SciMLBenchmarks
+# SimpleHandwrittenPDE spectral benchmarks:
+#   allen_cahn_spectral_wpd, burgers_spectral_wpd (Chebyshev collocation)
+#   kdv_spectral_wpd, ks_spectral_wpd (Fourier collocation)
+
+using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using SciMLBase: successful_retcode
+using ModelingToolkit: Differential, get_eqs, mtkcompile, get_unknowns, Symbolics
+
+const MOL = MethodOfLines
+
+# Independent reference: Chebyshev-Lobatto differentiation matrix, Trefethen
+# "Spectral Methods in MATLAB" construction on the descending grid x_j = cos(pi*j/N).
+function cheb_matrix_ref(N)
+    x = cospi.((0:N) / N)
+    c = [2; ones(N - 1); 2] .* (-1) .^ (0:N)
+    X = repeat(x, 1, N + 1)
+    dX = X - permutedims(X)
+    D = (c * permutedims(1 ./ c)) ./ (dX + I)
+    return D - Diagonal(vec(sum(D, dims = 2)))
+end
+
+# Map compiled unknowns `u(t)[k]` back to their grid indices.
+function unknown_perm(simpsys)
+    return map(get_unknowns(simpsys)) do uk
+        Int(Symbolics.value(arguments(Symbolics.unwrap(uk))[2]))
+    end
+end
+
+function ode_rhs(pdesys, disc)
+    sys, tspan = symbolic_discretize(pdesys, disc)
+    simpsys = mtkcompile(sys)
+    return ODEProblem(simpsys, nothing, tspan), unknown_perm(simpsys)
+end
+
+@testset "Collocation grids and differentiation matrices" begin
+    n = 8
+    grid = MOL.spectral_grid(ChebyshevCollocation(n), -1.0, 1.0)
+    @test grid ≈ -cospi.((0:(n - 1)) / (n - 1))
+    D2 = MOL.spectral_diff_matrix(ChebyshevCollocation(n), grid, 2)
+    Dref = (cheb_matrix_ref(n - 1)^2)[end:-1:1, end:-1:1]
+    @test D2 ≈ Dref atol = 1.0e-8
+
+    N = 16
+    a, b = -10.0, 10.0
+    gridf = MOL.spectral_grid(FourierCollocation(N), a, b)
+    @test length(gridf) == N + 1
+    @test gridf[end] - gridf[1] ≈ b - a
+    ξ = gridf[1:(end - 1)]
+    u = sin.(2π .* ξ ./ (b - a))
+    for (d, exact) in (
+            1 => (2π / (b - a)) .* cos.(2π .* ξ ./ (b - a)),
+            3 => -(2π / (b - a))^3 .* cos.(2π .* ξ ./ (b - a)),
+        )
+        Dd = MOL.spectral_diff_matrix(FourierCollocation(N), gridf, d)
+        @test norm(Dd * u - exact, Inf) < 1.0e-10
+    end
+end
+
+@testset "Allen-Cahn, Chebyshev collocation" begin
+    # u_t = 3(u - u^3) + eps u_xx, u(0,x) = cos(2pi x), u(t,+-1) = 1
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eps_ = 1.0e-3
+    eq = Dt(u(t, x)) ~ 3 * (u(t, x) - u(t, x)^3) + eps_ * Dxx(u(t, x))
+    bcs = [u(0, x) ~ cospi(2x), u(t, -1) ~ 1.0, u(t, 1) ~ 1.0]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-1.0, 1.0)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+
+    n = 32
+    disc = PseudospectralDiscretization([x => n], t)
+    discmap = get_discrete(pdesys, disc)
+    @test length(discmap[x]) == n
+
+    sys, tspan = symbolic_discretize(pdesys, disc)
+    # interior collocation equations plus two boundary conditions
+    @test length(get_eqs(sys)) == n
+
+    prob, perm = ode_rhs(pdesys, disc)
+    grid = discmap[x]
+    D2 = MOL.spectral_diff_matrix(ChebyshevCollocation(n), grid, 2)
+    ufull = ones(n)  # Dirichlet u(+-1) = 1
+    ufull[perm] = prob.u0
+    manual = (3 .* (ufull .- ufull .^ 3) .+ eps_ .* (D2 * ufull))[perm]
+    @test norm(prob.f(prob.u0, prob.p, 0.0) - manual, Inf) < 1.0e-10
+
+    prob_dae = discretize(pdesys, disc)
+    sol = solve(prob_dae; abstol = 1.0e-8, reltol = 1.0e-8)
+    @test successful_retcode(sol)
+    usol = sol[u(t, x)]
+    @test size(usol, 2) == n
+    @test all(isfinite, usol)
+    @test all(<(1.5), abs.(usol))
+end
+
+@testset "Burgers, Chebyshev collocation" begin
+    # u_t = -Dx(u^2) + nu u_xx, u(0,x) = exp(-x^2/(2*0.1^2)), u(t,+-1) = 0
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dxx = Dx^2
+
+    nu = 1.0e-2
+    u0func(x) = exp(-x^2 / (2 * 0.1^2))
+    bcs = [u(0, x) ~ u0func(x), u(t, -1) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.3), x ∈ Interval(-1.0, 1.0)]
+
+    n = 32
+    disc = PseudospectralDiscretization([x => n], t)
+
+    # Conservative form Dx(u^2)
+    eq = Dt(u(t, x)) ~ -Dx(u(t, x)^2) + nu * Dxx(u(t, x))
+    @named psys_c = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    prob_c, perm_c = ode_rhs(psys_c, disc)
+    grid = MOL.spectral_grid(ChebyshevCollocation(n), -1.0, 1.0)
+    D1 = MOL.spectral_diff_matrix(ChebyshevCollocation(n), grid, 1)
+    D2 = MOL.spectral_diff_matrix(ChebyshevCollocation(n), grid, 2)
+    ufull = zeros(n)
+    ufull[perm_c] = prob_c.u0
+    manual = (-D1 * (ufull .^ 2) .+ nu .* (D2 * ufull))[perm_c]
+    @test norm(prob_c.f(prob_c.u0, prob_c.p, 0.0) - manual, Inf) < 1.0e-10
+
+    # Convective form -u * Dx(u): equal up to collocation aliasing
+    eq = Dt(u(t, x)) ~ -u(t, x) * Dx(u(t, x)) + nu * Dxx(u(t, x))
+    @named psys_nc = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    prob_nc, perm_nc = ode_rhs(psys_nc, disc)
+    ufull_nc = zeros(n)
+    ufull_nc[perm_nc] = prob_nc.u0
+    manual_nc = (-ufull_nc .* (D1 * ufull_nc) .+ nu .* (D2 * ufull_nc))[perm_nc]
+    @test norm(prob_nc.f(prob_nc.u0, prob_nc.p, 0.0) - manual_nc, Inf) < 1.0e-10
+
+    sol = solve(discretize(psys_nc, disc); abstol = 1.0e-8, reltol = 1.0e-8)
+    @test successful_retcode(sol)
+    @test all(isfinite, sol[u(t, x)])
+end
+
+@testset "KdV, Fourier collocation" begin
+    # u_t = -6 u u_x - u_xxx, u(0,x) = cos(pi x/L), periodic on [-L, L]
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dxxx = Dx^3
+
+    L = 16.0
+    eq = Dt(u(t, x)) ~ -6 * u(t, x) * Dx(u(t, x)) - Dxxx(u(t, x))
+    bcs = [
+        u(0, x) ~ cospi(x / L),
+        u(t, -L) ~ u(t, L),
+        Dx(u(t, -L)) ~ Dx(u(t, L)),
+        (Dx^2)(u(t, -L)) ~ (Dx^2)(u(t, L)),
+    ]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-L, L)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+
+    N = 32
+    disc = PseudospectralDiscretization([x => FourierCollocation(N)], t)
+    discmap = get_discrete(pdesys, disc)
+    @test length(discmap[x]) == N + 1
+
+    sys, tspan = symbolic_discretize(pdesys, disc)
+    # N interior equations + the periodic alias condition; the derivative
+    # matching BCs are satisfied identically and skipped
+    @test length(get_eqs(sys)) == N + 1
+
+    prob, perm = ode_rhs(pdesys, disc)
+    grid = discmap[x]
+    D1 = MOL.spectral_diff_matrix(FourierCollocation(N), grid, 1)
+    D3 = MOL.spectral_diff_matrix(FourierCollocation(N), grid, 3)
+    ufull = zeros(N + 1)
+    ufull[perm] = prob.u0
+    ufull[1] = ufull[end]
+    udistinct = ufull[2:end]
+    manual = (-6 .* udistinct .* (D1 * udistinct) .- D3 * udistinct)[perm .- 1]
+    @test norm(prob.f(prob.u0, prob.p, 0.0) - manual, Inf) < 1.0e-9
+
+    # The Fourier differentiation matrix has zero column sums and is
+    # skew-symmetric, so the semi-discrete system conserves sum(du) = 0
+    # identically.
+    du0 = prob.f(prob.u0, prob.p, 0.0)
+    @test abs(sum(du0)) < 1.0e-10
+
+    sol = solve(discretize(pdesys, disc); abstol = 1.0e-8, reltol = 1.0e-8)
+    @test successful_retcode(sol)
+    usol = sol[u(t, x)]
+    @test all(isfinite, usol)
+end
+
+@testset "Kuramoto-Sivashinsky, Fourier collocation" begin
+    # u_t = -u u_x - 1/2 u_xx - 1/16 u_xxxx, u(0,x) = cos(2pi x/L), periodic
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+
+    L = 16.0
+    eq = Dt(u(t, x)) ~ -u(t, x) * Dx(u(t, x)) - (Dx^2)(u(t, x)) / 2 -
+        (Dx^4)(u(t, x)) / 16
+    bcs = [u(0, x) ~ cospi(2x / L), u(t, -L) ~ u(t, L)]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-L, L)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+
+    N = 32
+    disc = PseudospectralDiscretization([x => FourierCollocation(N)], t)
+    prob, perm = ode_rhs(pdesys, disc)
+    grid = get_discrete(pdesys, disc)[x]
+    D1 = MOL.spectral_diff_matrix(FourierCollocation(N), grid, 1)
+    D2 = MOL.spectral_diff_matrix(FourierCollocation(N), grid, 2)
+    D4 = MOL.spectral_diff_matrix(FourierCollocation(N), grid, 4)
+    ufull = zeros(N + 1)
+    ufull[perm] = prob.u0
+    ufull[1] = ufull[end]
+    udistinct = ufull[2:end]
+    manual = (
+        -udistinct .* (D1 * udistinct) .- (D2 * udistinct) / 2 .-
+            (D4 * udistinct) / 16
+    )[perm .- 1]
+    @test norm(prob.f(prob.u0, prob.p, 0.0) - manual, Inf) < 1.0e-9
+
+    sol = solve(discretize(pdesys, disc); abstol = 1.0e-8, reltol = 1.0e-8)
+    @test successful_retcode(sol)
+    @test all(isfinite, sol[u(t, x)])
+end
+
+@testset "Chebyshev manufactured solution" begin
+    # u = e^{-pi^2 t/4} cos(pi x/2), Dirichlet u(t,+-1) = 0
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+    bcs = [u(0, x) ~ cospi(x / 2), u(t, -1) ~ 0.0, u(t, 1) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-1.0, 1.0)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+
+    disc = PseudospectralDiscretization([x => 16], t)
+    sol = solve(discretize(pdesys, disc); abstol = 1.0e-10, reltol = 1.0e-10)
+    exact = [exp(-π^2 * ti / 4) * cospi(xi / 2) for ti in sol.t, xi in sol[x]]
+    @test norm(sol[u(t, x)] - exact, Inf) < 1.0e-6
+end
+
+@testset "Fourier manufactured solution" begin
+    # u = e^{-t} cos(x), periodic on [-pi, pi]
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dxx = Differential(x)^2
+
+    L = Float64(π)
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+    bcs = [u(0, x) ~ cos(x), u(t, -L) ~ u(t, L)]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-L, L)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+
+    disc = PseudospectralDiscretization([x => FourierCollocation(16)], t)
+    sol = solve(discretize(pdesys, disc); abstol = 1.0e-10, reltol = 1.0e-10)
+    exact = [exp(-ti) * cos(xi) for ti in sol.t, xi in sol[x]]
+    @test norm(sol[u(t, x)] - exact, Inf) < 1.0e-6
+end
+
+@testset "PseudospectralDiscretization errors" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    eq = Dt(u(t, x)) ~ (Dx^2)(u(t, x))
+    domains = [t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0)]
+
+    # FourierCollocation without a periodic boundary condition
+    bcs = [u(0, x) ~ 0.0, u(t, 0) ~ 0.0, u(t, 1) ~ 0.0]
+    @named psys1 = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    @test_throws ArgumentError symbolic_discretize(
+        psys1, PseudospectralDiscretization([x => FourierCollocation(8)], t)
+    )
+
+    # Periodic boundary condition on a non-Fourier direction
+    bcs = [u(0, x) ~ 0.0, u(t, 0) ~ u(t, 1)]
+    @named psys2 = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    @test_throws ArgumentError symbolic_discretize(
+        psys2, PseudospectralDiscretization([x => 8], t)
+    )
+
+    # Missing collocation specification
+    @parameters y
+    domains2 = [
+        t ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0),
+    ]
+    eq2 = Dt(u(t, x, y)) ~ (Dx^2)(u(t, x, y)) + (Differential(y)^2)(u(t, x, y))
+    bcs2 = [
+        u(0, x, y) ~ 0.0, u(t, 0, y) ~ 0.0, u(t, 1, y) ~ 0.0,
+        u(t, x, 0) ~ u(t, x, 1),
+    ]
+    @named psys3 = PDESystem([eq2], bcs2, domains2, [t, x, y], [u(t, x, y)])
+    @test_throws AssertionError symbolic_discretize(
+        psys3, PseudospectralDiscretization([x => 8], t)
+    )
+end

--- a/test/Pseudospectral/pseudospectral.jl
+++ b/test/Pseudospectral/pseudospectral.jl
@@ -4,6 +4,7 @@
 #   kdv_spectral_wpd, ks_spectral_wpd (Fourier collocation)
 
 using ModelingToolkit, MethodOfLines, LinearAlgebra, Test, OrdinaryDiffEq, DomainSets
+using NonlinearSolve
 using SciMLBase: successful_retcode
 using ModelingToolkit: Differential, get_eqs, mtkcompile, get_unknowns, Symbolics
 
@@ -33,6 +34,13 @@ function ode_rhs(pdesys, disc)
     return ODEProblem(simpsys, nothing, tspan), unknown_perm(simpsys)
 end
 
+# Residual of the `DAEProblem` `discretize` builds, at `u0` with `du` given.
+function dae_residual(prob, du)
+    res = similar(prob.u0)
+    prob.f(res, du, prob.u0, prob.p, 0.0)
+    return res
+end
+
 @testset "Collocation grids and differentiation matrices" begin
     n = 8
     grid = MOL.spectral_grid(ChebyshevCollocation(n), -1.0, 1.0)
@@ -57,6 +65,44 @@ end
     end
 end
 
+@testset "Array form: equation count is independent of resolution" begin
+    @parameters t x y
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dxx = Dx^2
+    Dyy = Differential(y)^2
+
+    eq = Dt(u(t, x)) ~ Dxx(u(t, x)) - u(t, x)^3
+    bcs = [u(0, x) ~ cospi(x / 2), u(t, -1) ~ 0.0, Dx(u(t, 1)) ~ 0.0]
+    domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-1.0, 1.0)]
+    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    # one interior array equation plus one scalar equation per boundary
+    for n in (8, 40)
+        sys, _ = symbolic_discretize(pdesys, PseudospectralDiscretization([x => n], t))
+        @test length(get_eqs(sys)) == 3
+        @test length(get_unknowns(sys)) == n
+    end
+
+    eq2 = Dt(u(t, x, y)) ~ Dxx(u(t, x, y)) + Dyy(u(t, x, y))
+    bcs2 = [
+        u(0, x, y) ~ cospi(x / 2) * cos(y), u(t, -1, y) ~ 0.0, Dx(u(t, 1, y)) ~ 0.0,
+        u(t, x, -Float64(π)) ~ u(t, x, Float64(π)),
+    ]
+    domains2 = [
+        t ∈ Interval(0.0, 0.2), x ∈ Interval(-1.0, 1.0),
+        y ∈ Interval(-Float64(π), Float64(π)),
+    ]
+    @named pdesys2 = PDESystem([eq2], bcs2, domains2, [t, x, y], [u(t, x, y)])
+    # interior, two x faces, the periodic y seam, and the two corners of the seam
+    for (n, m) in ((8, 8), (24, 20))
+        disc = PseudospectralDiscretization([x => n, y => FourierCollocation(m)], t)
+        sys, _ = symbolic_discretize(pdesys2, disc)
+        @test length(get_eqs(sys)) == 6
+        @test length(get_unknowns(sys)) == n * (m + 1)
+    end
+end
+
 @testset "Allen-Cahn, Chebyshev collocation" begin
     # u_t = 3(u - u^3) + eps u_xx, u(0,x) = cos(2pi x), u(t,+-1) = 1
     @parameters t x
@@ -75,10 +121,6 @@ end
     discmap = get_discrete(pdesys, disc)
     @test length(discmap[x]) == n
 
-    sys, tspan = symbolic_discretize(pdesys, disc)
-    # interior collocation equations plus two boundary conditions
-    @test length(get_eqs(sys)) == n
-
     prob, perm = ode_rhs(pdesys, disc)
     grid = discmap[x]
     D2 = MOL.spectral_diff_matrix(ChebyshevCollocation(n), grid, 2)
@@ -88,6 +130,7 @@ end
     @test norm(prob.f(prob.u0, prob.p, 0.0) - manual, Inf) < 1.0e-10
 
     prob_dae = discretize(pdesys, disc)
+    @test prob_dae isa DAEProblem
     sol = solve(prob_dae; abstol = 1.0e-8, reltol = 1.0e-8)
     @test successful_retcode(sol)
     usol = sol[u(t, x)]
@@ -111,20 +154,20 @@ end
 
     n = 32
     disc = PseudospectralDiscretization([x => n], t)
-
-    # Conservative form Dx(u^2)
-    eq = Dt(u(t, x)) ~ -Dx(u(t, x)^2) + nu * Dxx(u(t, x))
-    @named psys_c = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
-    prob_c, perm_c = ode_rhs(psys_c, disc)
     grid = MOL.spectral_grid(ChebyshevCollocation(n), -1.0, 1.0)
     D1 = MOL.spectral_diff_matrix(ChebyshevCollocation(n), grid, 1)
     D2 = MOL.spectral_diff_matrix(ChebyshevCollocation(n), grid, 2)
-    ufull = zeros(n)
-    ufull[perm_c] = prob_c.u0
-    manual = (-D1 * (ufull .^ 2) .+ nu .* (D2 * ufull))[perm_c]
-    @test norm(prob_c.f(prob_c.u0, prob_c.p, 0.0) - manual, Inf) < 1.0e-10
 
-    # Convective form -u * Dx(u): equal up to collocation aliasing
+    # Conservative form Dx(u^2), through the DAE residual of the array form
+    eq = Dt(u(t, x)) ~ -Dx(u(t, x)^2) + nu * Dxx(u(t, x))
+    @named psys_c = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    prob_c = discretize(psys_c, disc)
+    u0 = prob_c.u0
+    du = zeros(n)
+    du[2:(n - 1)] = (-D1 * (u0 .^ 2) .+ nu .* (D2 * u0))[2:(n - 1)]
+    @test norm(dae_residual(prob_c, du), Inf) < 1.0e-10
+
+    # Convective form -u * Dx(u), through the compiled ODE path
     eq = Dt(u(t, x)) ~ -u(t, x) * Dx(u(t, x)) + nu * Dxx(u(t, x))
     @named psys_nc = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
     prob_nc, perm_nc = ode_rhs(psys_nc, disc)
@@ -163,28 +206,26 @@ end
     @test length(discmap[x]) == N + 1
 
     sys, tspan = symbolic_discretize(pdesys, disc)
-    # N interior equations + the periodic alias condition; the derivative
-    # matching BCs are satisfied identically and skipped
-    @test length(get_eqs(sys)) == N + 1
+    # the interior array equation plus the periodic alias condition; the
+    # derivative matching BCs are satisfied identically and skipped
+    @test length(get_eqs(sys)) == 2
+    @test length(get_unknowns(sys)) == N + 1
 
-    prob, perm = ode_rhs(pdesys, disc)
+    prob = discretize(pdesys, disc)
     grid = discmap[x]
     D1 = MOL.spectral_diff_matrix(FourierCollocation(N), grid, 1)
     D3 = MOL.spectral_diff_matrix(FourierCollocation(N), grid, 3)
-    ufull = zeros(N + 1)
-    ufull[perm] = prob.u0
-    ufull[1] = ufull[end]
-    udistinct = ufull[2:end]
-    manual = (-6 .* udistinct .* (D1 * udistinct) .- D3 * udistinct)[perm .- 1]
-    @test norm(prob.f(prob.u0, prob.p, 0.0) - manual, Inf) < 1.0e-9
+    ud = prob.u0[2:end]
+    f = -6 .* ud .* (D1 * ud) .- D3 * ud
+    du = vcat(f[end], f)
+    @test norm(dae_residual(prob, du), Inf) < 1.0e-9
 
     # The Fourier differentiation matrix has zero column sums and is
     # skew-symmetric, so the semi-discrete system conserves sum(du) = 0
     # identically.
-    du0 = prob.f(prob.u0, prob.p, 0.0)
-    @test abs(sum(du0)) < 1.0e-10
+    @test abs(sum(f)) < 1.0e-10
 
-    sol = solve(discretize(pdesys, disc); abstol = 1.0e-8, reltol = 1.0e-8)
+    sol = solve(prob; abstol = 1.0e-8, reltol = 1.0e-8)
     @test successful_retcode(sol)
     usol = sol[u(t, x)]
     @test all(isfinite, usol)
@@ -226,22 +267,115 @@ end
     @test all(isfinite, sol[u(t, x)])
 end
 
-@testset "Chebyshev manufactured solution" begin
-    # u = e^{-pi^2 t/4} cos(pi x/2), Dirichlet u(t,+-1) = 0
+@testset "Chebyshev manufactured solutions" begin
     @parameters t x
-    @variables u(..)
+    @variables u(..) v(..)
     Dt = Differential(t)
-    Dxx = Differential(x)^2
-
-    eq = Dt(u(t, x)) ~ Dxx(u(t, x))
-    bcs = [u(0, x) ~ cospi(x / 2), u(t, -1) ~ 0.0, u(t, 1) ~ 0.0]
+    Dx = Differential(x)
+    Dxx = Dx^2
     domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-1.0, 1.0)]
-    @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
 
-    disc = PseudospectralDiscretization([x => 16], t)
-    sol = solve(discretize(pdesys, disc); abstol = 1.0e-10, reltol = 1.0e-10)
-    exact = [exp(-π^2 * ti / 4) * cospi(xi / 2) for ti in sol.t, xi in sol[x]]
-    @test norm(sol[u(t, x)] - exact, Inf) < 1.0e-6
+    function solve_and_compare(pdesys, disc, exact; tol = 1.0e-6, kwargs...)
+        sol = solve(discretize(pdesys, disc); abstol = 1.0e-10, reltol = 1.0e-10)
+        @test successful_retcode(sol)
+        ex = [exact(ti, xi) for ti in sol.t, xi in sol[x]]
+        @test norm(sol[u(t, x)] - ex, Inf) < tol
+        return sol
+    end
+
+    @testset "Dirichlet" begin
+        # u = e^{-pi^2 t/4} cos(pi x/2)
+        eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+        bcs = [u(0, x) ~ cospi(x / 2), u(t, -1) ~ 0.0, u(t, 1) ~ 0.0]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+        solve_and_compare(
+            pdesys, PseudospectralDiscretization([x => 16], t),
+            (ti, xi) -> exp(-π^2 * ti / 4) * cospi(xi / 2)
+        )
+        # the same problem on a custom (here Chebyshev-Lobatto) node vector
+        nodes = -cospi.((0:15) ./ 15)
+        solve_and_compare(
+            pdesys, PseudospectralDiscretization([x => nodes], t),
+            (ti, xi) -> exp(-π^2 * ti / 4) * cospi(xi / 2)
+        )
+    end
+
+    @testset "Neumann" begin
+        # u = e^{-pi^2 t/4} sin(pi x/2), u_x(t, +-1) = 0
+        eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+        bcs = [u(0, x) ~ sinpi(x / 2), Dx(u(t, -1)) ~ 0.0, Dx(u(t, 1)) ~ 0.0]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+        solve_and_compare(
+            pdesys, PseudospectralDiscretization([x => 20], t),
+            (ti, xi) -> exp(-π^2 * ti / 4) * sinpi(xi / 2)
+        )
+    end
+
+    @testset "Robin" begin
+        # u = e^{-t} e^{x}: u_t = u_xx - 2u, u_x - u = 0 at both ends
+        eq = Dt(u(t, x)) ~ Dxx(u(t, x)) - 2u(t, x)
+        bcs = [u(0, x) ~ exp(x), Dx(u(t, -1)) - u(t, -1) ~ 0.0, Dx(u(t, 1)) ~ u(t, 1)]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+        solve_and_compare(
+            pdesys, PseudospectralDiscretization([x => 20], t),
+            (ti, xi) -> exp(-ti + xi)
+        )
+    end
+
+    @testset "Time-dependent Dirichlet" begin
+        # u = e^{t + x}
+        eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+        bcs = [u(0, x) ~ exp(x), u(t, -1) ~ exp(t - 1), u(t, 1) ~ exp(t + 1)]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+        solve_and_compare(
+            pdesys, PseudospectralDiscretization([x => 20], t),
+            (ti, xi) -> exp(ti + xi)
+        )
+    end
+
+    @testset "Second-order boundary condition" begin
+        # u = e^{-pi^2 t} sin(pi x), u_xx(t, +-1) = 0
+        eq = Dt(u(t, x)) ~ Dxx(u(t, x))
+        bcs = [u(0, x) ~ sinpi(x), Dxx(u(t, -1)) ~ 0.0, Dxx(u(t, 1)) ~ 0.0]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+        solve_and_compare(
+            pdesys, PseudospectralDiscretization([x => 16], t),
+            (ti, xi) -> exp(-π^2 * ti) * sinpi(xi); tol = 1.0e-5
+        )
+    end
+
+    @testset "Nested nonlinear laplacian" begin
+        # u = e^{-t}(1 - x^2), forced so that u_t = Dx((1 + x^2) Dx(u)) + g - u
+        eq = Dt(u(t, x)) ~ Dx((1 + x^2) * Dx(u(t, x))) + exp(-t) * (2 + 6x^2) - u(t, x)
+        bcs = [u(0, x) ~ 1 - x^2, u(t, -1) ~ 0.0, u(t, 1) ~ 0.0]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+        solve_and_compare(
+            pdesys, PseudospectralDiscretization([x => 12], t),
+            (ti, xi) -> exp(-ti) * (1 - xi^2)
+        )
+    end
+
+    @testset "Coupled system" begin
+        # u = e^{-pi^2 t/4} cos(pi x/2) cos t, v = -e^{-pi^2 t/4} cos(pi x/2) sin t
+        eqs = [
+            Dt(u(t, x)) ~ Dxx(u(t, x)) + v(t, x),
+            Dt(v(t, x)) ~ Dxx(v(t, x)) - u(t, x),
+        ]
+        bcs = [
+            u(0, x) ~ cospi(x / 2), v(0, x) ~ 0.0,
+            u(t, -1) ~ 0.0, u(t, 1) ~ 0.0, v(t, -1) ~ 0.0, v(t, 1) ~ 0.0,
+        ]
+        @named pdesys = PDESystem(eqs, bcs, domains, [t, x], [u(t, x), v(t, x)])
+        disc = PseudospectralDiscretization([x => 16], t)
+        sys, _ = symbolic_discretize(pdesys, disc)
+        @test length(get_eqs(sys)) == 6
+        sol = solve(discretize(pdesys, disc); abstol = 1.0e-10, reltol = 1.0e-10)
+        @test successful_retcode(sol)
+        exu = [exp(-π^2 * ti / 4) * cospi(xi / 2) * cos(ti) for ti in sol.t, xi in sol[x]]
+        exv = [-exp(-π^2 * ti / 4) * cospi(xi / 2) * sin(ti) for ti in sol.t, xi in sol[x]]
+        @test norm(sol[u(t, x)] - exu, Inf) < 1.0e-6
+        @test norm(sol[v(t, x)] - exv, Inf) < 1.0e-6
+    end
 end
 
 @testset "Fourier manufactured solution" begin
@@ -257,10 +391,86 @@ end
     domains = [t ∈ Interval(0.0, 0.5), x ∈ Interval(-L, L)]
     @named pdesys = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
 
-    disc = PseudospectralDiscretization([x => FourierCollocation(16)], t)
-    sol = solve(discretize(pdesys, disc); abstol = 1.0e-10, reltol = 1.0e-10)
-    exact = [exp(-ti) * cos(xi) for ti in sol.t, xi in sol[x]]
-    @test norm(sol[u(t, x)] - exact, Inf) < 1.0e-6
+    for N in (16, 15)
+        disc = PseudospectralDiscretization([x => FourierCollocation(N)], t)
+        sol = solve(discretize(pdesys, disc); abstol = 1.0e-10, reltol = 1.0e-10)
+        exact = [exp(-ti) * cos(xi) for ti in sol.t, xi in sol[x]]
+        @test norm(sol[u(t, x)] - exact, Inf) < 1.0e-6
+    end
+end
+
+@testset "Two spatial dimensions" begin
+    @parameters t x y
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    Dxx = Dx^2
+    Dyy = Differential(y)^2
+    eq = Dt(u(t, x, y)) ~ Dxx(u(t, x, y)) + Dyy(u(t, x, y))
+
+    @testset "Chebyshev x Chebyshev, Dirichlet" begin
+        # u = e^{-pi^2 t/2} cos(pi x/2) cos(pi y/2)
+        bcs = [
+            u(0, x, y) ~ cospi(x / 2) * cospi(y / 2),
+            u(t, -1, y) ~ 0.0, u(t, 1, y) ~ 0.0, u(t, x, -1) ~ 0.0, u(t, x, 1) ~ 0.0,
+        ]
+        domains = [
+            t ∈ Interval(0.0, 0.2), x ∈ Interval(-1.0, 1.0), y ∈ Interval(-1.0, 1.0),
+        ]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x, y], [u(t, x, y)])
+        disc = PseudospectralDiscretization([x => 12, y => 12], t)
+        sys, _ = symbolic_discretize(pdesys, disc)
+        # interior, four faces, four corners
+        @test length(get_eqs(sys)) == 9
+        sol = solve(discretize(pdesys, disc); abstol = 1.0e-9, reltol = 1.0e-9)
+        @test successful_retcode(sol)
+        usol = sol[u(t, x, y)]
+        exact = [
+            exp(-π^2 * ti / 2) * cospi(xi / 2) * cospi(yi / 2)
+                for ti in sol.t, xi in sol[x], yi in sol[y]
+        ]
+        @test norm(usol - exact, Inf) < 1.0e-6
+    end
+
+    @testset "Chebyshev x Fourier, Neumann face" begin
+        # u = e^{-(pi^2/16 + 1) t} sin(pi (x + 1)/4) cos(y): u(t, -1, y) = 0, u_x(t, 1, y) = 0
+        Lp = Float64(π)
+        bcs = [
+            u(0, x, y) ~ sinpi((x + 1) / 4) * cos(y),
+            u(t, -1, y) ~ 0.0, Dx(u(t, 1, y)) ~ 0.0, u(t, x, -Lp) ~ u(t, x, Lp),
+        ]
+        domains = [
+            t ∈ Interval(0.0, 0.2), x ∈ Interval(-1.0, 1.0), y ∈ Interval(-Lp, Lp),
+        ]
+        @named pdesys = PDESystem([eq], bcs, domains, [t, x, y], [u(t, x, y)])
+        disc = PseudospectralDiscretization([x => 14, y => FourierCollocation(12)], t)
+        sol = solve(discretize(pdesys, disc); abstol = 1.0e-9, reltol = 1.0e-9)
+        @test successful_retcode(sol)
+        usol = sol[u(t, x, y)]
+        exact = [
+            exp(-(π^2 / 16 + 1) * ti) * sinpi((xi + 1) / 4) * cos(yi)
+                for ti in sol.t, xi in sol[x], yi in sol[y]
+        ]
+        # The corner points at the periodic alias index (y = -pi) are pinned to
+        # zero by the corner equations, as on the finite difference path, so
+        # compare on the distinct periodic points only.
+        @test norm(usol[:, :, 2:end] - exact[:, :, 2:end], Inf) < 1.0e-6
+    end
+end
+
+@testset "Stationary problem" begin
+    # u'' = -pi^2/4 cos(pi x/2), u(+-1) = 0  =>  u = cos(pi x/2)
+    @parameters x
+    @variables u(..)
+    Dxx = Differential(x)^2
+    eq = Dxx(u(x)) ~ -π^2 / 4 * cospi(x / 2)
+    bcs = [u(-1) ~ 0.0, u(1) ~ 0.0]
+    @named pdesys = PDESystem([eq], bcs, [x ∈ Interval(-1.0, 1.0)], [x], [u(x)])
+    prob = discretize(pdesys, PseudospectralDiscretization([x => 16]))
+    @test prob isa NonlinearProblem
+    sol = solve(prob, NewtonRaphson())
+    @test successful_retcode(sol)
+    @test norm(sol[u(x)] - cospi.(sol[x] ./ 2), Inf) < 1.0e-10
 end
 
 @testset "PseudospectralDiscretization errors" begin
@@ -285,6 +495,13 @@ end
         psys2, PseudospectralDiscretization([x => 8], t)
     )
 
+    # A jump in a derivative matching condition cannot be represented
+    bcs = [u(0, x) ~ 0.0, u(t, 0) ~ u(t, 1), Dx(u(t, 0)) ~ Dx(u(t, 1)) + 1.0]
+    @named psys4 = PDESystem([eq], bcs, domains, [t, x], [u(t, x)])
+    @test_throws ArgumentError symbolic_discretize(
+        psys4, PseudospectralDiscretization([x => FourierCollocation(8)], t)
+    )
+
     # Missing collocation specification
     @parameters y
     domains2 = [
@@ -299,4 +516,8 @@ end
     @test_throws AssertionError symbolic_discretize(
         psys3, PseudospectralDiscretization([x => 8], t)
     )
+
+    @test_throws ArgumentError ChebyshevCollocation(1)
+    @test_throws ArgumentError FourierCollocation(3)
+    @test_throws ArgumentError PseudospectralDiscretization([x => "eight"], t)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ const FUNCTIONAL_GROUPS = [
     "Convection_NU",
     "Wave_Eq_Staggered",
     "Discretization",
+    "Pseudospectral",
 ]
 
 run_tests(;
@@ -115,6 +116,7 @@ run_tests(;
             end
         end,
         "Wave_Eq_Staggered" => joinpath(@__DIR__, "Wave_Eq_Staggered", "wave_eq_staggered.jl"),
+        "Pseudospectral" => joinpath(@__DIR__, "Pseudospectral", "pseudospectral.jl"),
         "Discretization" => function ()
             @safetestset "Equation discretization" begin
                 include(joinpath(@__DIR__, "Discretization", "equation_discretization.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,7 +116,14 @@ run_tests(;
             end
         end,
         "Wave_Eq_Staggered" => joinpath(@__DIR__, "Wave_Eq_Staggered", "wave_eq_staggered.jl"),
-        "Pseudospectral" => joinpath(@__DIR__, "Pseudospectral", "pseudospectral.jl"),
+        "Pseudospectral" => function ()
+            @safetestset "Pseudospectral discretization" begin
+                include(joinpath(@__DIR__, "Pseudospectral", "pseudospectral.jl"))
+            end
+            return @safetestset "Pseudospectral FFT extension and 3D" begin
+                include(joinpath(@__DIR__, "Pseudospectral", "fft.jl"))
+            end
+        end,
         "Discretization" => function ()
             @safetestset "Equation discretization" begin
                 include(joinpath(@__DIR__, "Discretization", "equation_discretization.jl"))

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -61,6 +61,9 @@ versions = ["lts", "1", "pre"]
 [Discretization]
 versions = ["lts", "1", "pre"]
 
+[Pseudospectral]
+versions = ["lts", "1", "pre"]
+
 [Complex]
 versions = ["lts", "1", "pre"]
 


### PR DESCRIPTION
> Draft. Please ignore until reviewed by @ChrisRackauckas.

## Summary

Adds `PseudospectralDiscretization`, a collocation discretization with `ChebyshevCollocation(n)` (Chebyshev–Lobatto nodes, polynomial-interpolant differentiation matrices), `FourierCollocation(n)` (equispaced periodic nodes, trigonometric-interpolant matrices) and custom node vectors, inside MethodOfLines.jl with no new dependencies. It reuses the `VariableMap`/`boundarymap`/`InteriorMap`/`DiscreteSpace`/`EquationState` parsing, the boundary-condition machinery, `mtkcompile`/`DAEProblem`/`NonlinearProblem` construction and the `sol[u(t, x)]` solution interface; the discretization-specific parts are grid construction, the differentiation matrices, and equation generation. Shared entry points were widened to `MOLDiscretization = Union{MOLFiniteDifference, PseudospectralDiscretization}`.

**What it is, precisely.** Collocation in physical (grid) space: unknowns are nodal values, each `Differential(x)^d` is a dense differentiation matrix, nonlinear terms are evaluated pointwise on the grid. No FFTs are used and nothing is solved in coefficient space; a Fourier direction uses the dense trigonometric differentiation matrix, which is what the `SummationByPartsOperators` operator in the KdV/KS benchmarks becomes after `Matrix(D)`. The Chebyshev benchmarks use rectangular collocation with a resampling mass matrix; here it is square Lobatto collocation with boundary-row replacement (Trefethen's `cheb`). Both are spectrally accurate; the operators differ.

**Array form (second commit).** The first commit generated one scalar equation per node, each a dense `n`-term row, so the symbolic system was `O(n^2)` and the KS benchmark at its published size (128 Fourier points) took ~70 s to build and compile. The interior is now emitted as one array equation over slices, with each derivative an opaque `SpectralApply` operator holding its matrix block and applying it along its axis (`Dsub * u` / `u * Dsub'`), nested derivatives evaluated on the full direction first (`Dx(a(u)*Dx(u))` → `D1 * (a.(u) .* (D1 * u))`), and 2D faces going through `array_bc_eqs` with a spectral method of the new `array_boundary_derivative_expr` helper (a one-block refactor of the finite-difference loop, behaviour unchanged). 3D, stationary systems and patterns without a slice form fall back to the pointwise path. The `DAEProblem` from `discretize` keeps the array form; `mtkcompile` scalarizes it but the generated code evaluates each matrix product once (CSE), verified by timing.

**Boundary conditions.** Chebyshev: the PDE is imposed at interior nodes and each boundary node's equation is replaced by the BC; a derivative in a BC is the boundary row of the differentiation matrix over all `n` values. Dirichlet (constant/time-dependent/face-varying), Neumann, Robin, nonlinear, second-order, several conditions per end (clamped beam), and one-sided conditions (advection) all work; each condition removes one more node from the interior at that end. Boundary values are algebraic unknowns, so `discretize` returns an index-1 `DAEProblem` with `BrownFullBasicInit`. Fourier: `n + 1` stored points with the last aliasing the first, pinned by `u(t,a) ~ u(t,b)`; derivative matching conditions are checked to hold identically and skipped; a jump in one raises an error; truncating BCs are rejected. All of this is now in `docs/src/pseudospectral.md`.


**FFT derivatives and N-dimensional array form (third commit).** A new `MethodOfLinesAbstractFFTsExt` extension (weak dependency `AbstractFFTs`, MIT; `FFTW` added as a test dependency only, its `FFTW_jll` is GPL and stays out of `[deps]`) makes every `FourierCollocation` direction apply whole-direction derivatives as `irfft((ik)^d .* rfft(u))` along its axis once a backend is loaded, with the Nyquist mode zeroed so the result equals the dense `D1^d` to roundoff. Boundary rows, pinned rows and dual-number (Jacobian) evaluations keep the dense matrix, which the operator carries; `FourierCollocation(n; fft = false)` opts out. `apply_along` contracts an operator over any axis of an array of any rank, so the slice form now covers 3D and above instead of falling back to pointwise; a 3D Chebyshev×Chebyshev×Fourier heat problem has 18 symbolic equations at 8³, 16³ and 24³ and matches its manufactured solution to 1e-10 away from the periodic alias corners.

Does the FFT make a noticeable difference? For the residual evaluation yes at large `n`, no below a few hundred points, and it does not change the compile-time story:

| KS, `FourierCollocation(N)` | dense `prob.f` call | FFT `prob.f` call | max abs difference |
|---|---|---|---|
| N = 64 | 12.6 µs | 13.9 µs | 3e-14 |
| N = 256 | 46 µs | 26 µs | 3e-11 |
| N = 1024 | 760 µs | 105 µs | 9e-9 |
| N = 4096 | 14.8 ms | 0.36 ms | 3e-5 (dense `D1^4` roundoff) |

Full KS solve at N = 1024 with the default `DFBDF`, 2081 `f` calls: 1.83 s dense vs 1.09 s FFT; the rest is the dense Jacobian and linear algebra, which the FFT does not touch. On a 128×128 periodic 2D heat problem the residual costs 1.5 ms dense vs 1.4 ms FFT, because the per-element scalarized residual (https://github.com/SciML/MethodOfLines.jl/issues/691) dominates, and `discretize` takes about two minutes either way for the 16,641 unknowns. 3D 24³ (13,824 unknowns): 75 s `discretize`, 1.2 ms per `f` call.

Extension verification: `GROUP=Pseudospectral` now runs two safetestsets, 70 + 174 tests, both passing (after the fourth commit); `GROUP=QA` 21/21 with the extension (Aqua, ExplicitImports, JET); Runic and typos clean; docs build renders the new "FFT derivatives" section.

**Review follow-up (fourth commit).** Chebyshev directions now go through the FFT as well: the DCT-I of each line is the real FFT of its even extension, the derivative's Chebyshev coefficients come from the backward recurrence `b[k-1] = b[k+1] + 2k a[k]` applied `d` times, and the same transform maps back to the nodes; the interior equation slices the interior rows out of the whole-direction derivative (the boundary rows are the ones the boundary conditions replace). Both FFT operators cache plans and buffers and apply in place. Agreement with the dense matrices is 1e-13 to 1e-9 relative for orders 1 to 4 (tests). The transform length is `2(n - 1)`, so `n = 2^k + 1` is fastest.

While benchmarking this I found that the dense Chebyshev matrix built from full-stencil Fornberg weights overflows to NaN beyond about a thousand nodes (`n = 1025`: `D1` is NaN), which also breaks the FFT path's Jacobians. `spectral_diff_matrix` for `ChebyshevCollocation` now uses the Weideman–Reddy `chebdif` recursion: equal to Fornberg to 1e-12 for `n ≤ 513` (and more accurate for `D2` there: 8.6e-7 vs 4.9e-6 on `exp(sin(3x))`), finite and accurate at 1025 and 2049. Custom node vectors keep Fornberg.

Burgers on Chebyshev nodes, `prob.f` call (Julia 1.10.11, FFTW):

| n | dense | FFT |
|---|---|---|
| 65 | 9.5 µs | 14.7 µs |
| 257 | 46 µs | 38 µs |
| 1025 | 198 µs | 113 µs |
| 4097 | 8.3 ms | 0.49 ms |

Bare operator on a vector, `n = 1024` vs `1025`: FFT 78 µs vs 22 µs (length 2046 has a factor 31), dense 34 µs vs 79 µs. Full Burgers solve at 257 nodes: 0.15 s either way.

Docs: the struct listing and the benchmark-comparison paragraph are gone; the intro says both directions use FFTs with a backend loaded.

**QA on a fresh Manifest.** `GROUP=QA` passed on 2026-09-11 (21/21) but on a Manifest resolved on 2026-09-12 it fails two ExplicitImports "via owners" checks on pre-existing imports in `src/MethodOfLines.jl` (`get_eqs`, `get_unknowns`, `ProblemTypeCtx`, `VariableBounds`, ... now reported as owned by `ModelingToolkitBase`). Nothing in this PR touches those lines; it reproduces with the new dependency versions on master and is being handled separately.

## Verification

`GROUP=Pseudospectral julia --project -e 'using Pkg; Pkg.test()'` (Julia 1.10.11):

```
Test Summary:  | Pass  Total     Time
Pseudospectral |   70     70  4m36.5s
```

Covers: differentiation matrices against Trefethen's `cheb` and exact trigonometric derivatives; equation count independent of resolution (3 equations in 1D at n = 8 and 40, 6 in 2D Chebyshev×Fourier at 8×8 and 24×20); DAE residual of the array form against handwritten `D1`/`D2`/`D3`/`D4` matrix products for Allen–Cahn, Burgers (conservative and convective), KdV and KS to 1e-9; manufactured solutions to ≤1e-6 (measured 1e-10–1e-11) for Dirichlet, custom nodes, Neumann, Robin, time-dependent Dirichlet, second-order BCs, nested `Dx((1+x^2) Dx u)`, a coupled two-variable system, Fourier (even and odd `n`), 2D Chebyshev×Chebyshev and 2D Chebyshev×Fourier with a Neumann face, and a stationary `NonlinearProblem`; error cases.

Shared-code groups run locally after the `array_bc_eqs` refactor, all passing with only the pre-existing `@test_broken` entries: `2D_Diffusion` (2/2), `DAE` (22/22), `Higher_Order` (1 + 2 broken), `Mixed_Derivatives` (2 + 3 broken), `Nonlinear_Diffusion` (10 + 2 broken), `Integrals` (2 + 2 broken), `Diffusion` (269/269), `Components`, `Discretization`, `Brusselator`, `QA` — see the log tails below.

- `GROUP=2D_Diffusion`: passed — `Test Summary: | Pass Total Time / 2D_Diffusion | 2 2 4m04.3s`
- `GROUP=DAE`: passed — `Test Summary: | Pass Total Time / DAE | 22 22 2m43.7s`
- `GROUP=Higher_Order`: passed — `Test Summary: | Pass Broken Total Time / Higher_Order | 1 2 3 4m28.5s`
- `GROUP=Mixed_Derivatives`: passed — `Test Summary: | Pass Broken Total Time / Mixed_Derivatives | 2 3 5 7m36.7s`
- `GROUP=Nonlinear_Diffusion`: passed — `Test Summary: | Pass Broken Total Time / Nonlinear_Diffusion | 10 2 12 4m04.6s`
- `GROUP=Integrals`: passed — `Test Summary: | Pass Broken Total Time / Integrals | 2 2 4 2m38.4s`
- `GROUP=Diffusion`: passed — `Test Summary: | Pass Total Time / Diffusion | 269 269 8m27.5s`
- `GROUP=Components`: passed — `Test Summary: | Pass Total Time / Discrete Callbacks | 1 1 43.6s`
- `GROUP=Discretization`: passed — `Test Summary: | Pass Total Time / Problem construction | 54 54 1m13.9s`
- `GROUP=Brusselator`: passed — `Test Summary: | Pass Total Time / Brusselator | 1154 1154 27m40.2s`
- `GROUP=QA`: passed — `Test Summary: | Pass Total Time / QA | 21 21 13m45.0s`
- `GROUP=Sol_Interface`: passed — `Test Summary: | Pass Total Time / Sol_Interface | 18 18 5m23.2s`
- `GROUP=MOL_Interface1`: passed — `Test Summary: | Total Time / MOL_Interface1 | 0 12m49.2s`
- `GROUP=MOL_Interface2`: passed — `Test Summary: | Pass Broken Total Time / MOL_Interface2 | 8 5 13 7m36.9s`
- `GROUP=Stationary`: passed — `Test Summary: | Pass Total Time / Stationary | 8 8 4m00.6s`
- `GROUP=Complex`: passed — `Test Summary: | Pass Total Time / Complex | 102 102 2m45.3s`
- `GROUP=Convection`: passed — `Test Summary: | Pass Broken Total Time / Convection | 8 1 9 4m16.1s`
- `GROUP=Convection_WENO`: passed — `Test Summary: | Pass Total Time / WENO Non-Uniform Interface/Periodic | 31 31 4m11.8s`
- `GROUP=Convection_NU`: passed — `Test Summary: | Pass Total Time / Linear Convection, Upwind Non-Uniform Interfaces | 109 109 3m10.7s`
- `GROUP=Diffusion_NU`: passed — `Test Summary: | Pass Total Time / Diffusion_NU | 150 150 6m10.4s`
- `GROUP=Nonlinear_Diffusion_NU`: passed — `Test Summary: | Pass Broken Total Time / Nonlinear_Diffusion_NU | 13 2 15 3m56.2s`
- `GROUP=Nonlinlap_ADV`: passed — `Test Summary: | Broken Total Time / Nonlinlap_ADV | 1 1 2m57.3s`
- `GROUP=Burgers`: passed — `Test Summary: | Pass Total Time / Burgers | 128 128 3m28.8s`
- `GROUP=Wave_Eq_Staggered`: passed — `Test Summary: | Pass Broken Total Time / Wave_Eq_Staggered | 1 5 6 3m38.3s`

Runic (`--check`) and `typos` clean on every changed file. Docs build: `julia --project=docs docs/make.jl` ran to `RenderDocument` with no errors and the new page and the `SpectralApply` docstring rendered; the only failure in a full run was `linkcheck` returning HTTP 429 (GitHub rate limiting) on two pre-existing links in other pages, so the reported build used `linkcheck = false`.

Compile scaling, KS with `FourierCollocation(N)`, `discretize` + first `prob.f` call, Julia 1.10.11:

| N | pointwise (first commit) | array form (this PR) | `MOLFiniteDifference` order 4 |
|---|---|---|---|
| 64 | 9.2 s | 0.5 s | 0.5 s |
| 128 | 69.6 s | 0.6 s | 0.9 s |
| 256 | – | 1.2 s | 1.0 s |
| 1024 | – | 11.6 s | 6.0 s |

`prob.f` runtime at N = 1024 is 226 µs, consistent with one dense matrix product per derivative per call. Neither path is resolution-independent at the compiled-code level: MTK's DAE codegen scalarizes the array residual, which is a pre-existing property of the finite-difference array path too (measured 15.8 s `discretize` + 25.5 s first call at 4097 FD points). Filed as https://github.com/SciML/MethodOfLines.jl/issues/691.

## Not verified / known gaps

- The FFT path is only exercised with the FFTW backend; other AbstractFFTs backends are untested.
- Corner grid points at the alias index of a periodic direction are pinned to zero by the shared corner equations, exactly as on the finite-difference path; the 2D Chebyshev×Fourier test compares on the distinct periodic points. Same pre-existing behaviour with `MOLFiniteDifference`.
- `Integral` terms and multi-domain interface BCs raise errors.
- Allowed-to-fail CI lanes (`julia pre`, downstream) not run locally.

## Things to push back on

- `apply_along` loops `mul!` over the trailing axes for a middle axis in ≥3D; a tensor library would be faster.
- FFT plans are cached per array size in a `Dict` inside the operator, which is not thread-safe if the same problem is evaluated concurrently.
- The Chebyshev operator is square Lobatto collocation, not the rectangular collocation the Allen–Cahn/Burgers benchmarks use.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01RuwNgkber23fDw3ijCb21J

The first commit was produced by a different agent session (Devin CLI 3000.10.21, model SWE-2 Max, local session `tourmaline-street`); the second commit and this description come from the Claude Code session linked above.
