### PR TITLE
Fix JET possible-undef finding in spectral_array_derivative

### DIFF
--- a/src/discretization/pseudospectral_discretize.jl
+++ b/src/discretization/pseudospectral_discretize.jl
@@ -288,7 +288,8 @@ function spectral_array_derivative(term, ranges, c::SpectralArrayContext)
         full = spectral_apply_along(D.fast, j, val)
         length(rows) == size(D.mat, 1) && return full
         # differentiate on every node, then keep the rows asked for
-        rs = ntuple(k -> k == j ? (first(rows):last(rows)) : (1:size(full, k)), ndims(full))
+        rowrange = first(rows):last(rows)
+        rs = ntuple(k -> k == j ? rowrange : (1:size(full, k)), ndims(full))
         return full[rs...]
     end
     return spectral_apply_along(D.mat[rows, :], j, val)


### PR DESCRIPTION
## Summary

CI's QA job (`JET.test_package(MethodOfLines; target_modules = (MethodOfLines,), mode = :typo)` on Julia 1.13) reports one finding:

```
local variable 'rows' is not defined
```

in `spectral_array_derivative`. `rows` is assigned unconditionally at the top of the loop body but conditionally reassigned in an `if`; Julia 1.13 lowering boxes the captured variable and emits `isdefined`-guarded reads, and JET flags the guard as a possible-undef path even though it is unreachable at runtime.

The fix computes `first(rows):last(rows)` into a fresh `rowrange` local, so the `ntuple` closure captures a variable with exactly one assignment — no box, no guarded read, no finding.

## Test plan

- [x] `JET.test_package(MethodOfLines; target_modules = (MethodOfLines,), mode = :typo)` on Julia 1.13.0: **1/1 pass** (previously 1 report)
- [x] Finding reproduced on unfixed code under JET 0.11.6 and 0.12.1; minimal repro confirms the box-lowering trigger

🤖 Generated with [Devin CLI](https://devin.ai) (harness: Devin CLI 3000.10.21, model: SWE-2 Max)
Session (local transcript, no shareable URL): `/home/crackauc/.local/share/devin/cli/summaries/history_1130a74e0ebc4347.md`